### PR TITLE
Prompt Designer - Error toast and split nodes

### DIFF
--- a/packages/app/src/components/PromptDesigner.tsx
+++ b/packages/app/src/components/PromptDesigner.tsx
@@ -26,10 +26,12 @@ import {
   PortId,
   ProcessId,
   Settings,
+  arrayizeDataValue,
   coerceType,
   coerceTypeOptional,
   getChatNodeMessages,
   getError,
+  isArrayDataValue,
   modelOptions,
 } from '@ironclad/rivet-core';
 import TextField from '@atlaskit/textfield';
@@ -43,7 +45,7 @@ import { settingsState } from '../state/settings';
 import { GraphSelector } from './DefaultNodeEditor';
 import TextArea from '@atlaskit/textarea';
 import { projectState } from '../state/savedGraphs';
-import { cloneDeep, findIndex, range, zip } from 'lodash-es';
+import { cloneDeep, findIndex, mapValues, range, zip } from 'lodash-es';
 import { useStableCallback } from '../hooks/useStableCallback';
 import { toast } from 'react-toastify';
 import { produce } from 'immer';
@@ -346,7 +348,12 @@ export const PromptDesigner: FC<PromptDesignerProps> = ({ onClose }) => {
       : undefined;
 
     if (nodeDataForAttachedNodeProcess?.inputData) {
-      const { messages } = getChatNodeMessages(nodeDataForAttachedNodeProcess.inputData);
+      let inputData = nodeDataForAttachedNodeProcess.inputData;
+      // If node is a split run, just grab the first input data.
+      if (attachedNode.isSplitRun) {
+        inputData = mapValues(inputData, (val) => isArrayDataValue(val) ? arrayizeDataValue(val)[0] : val);
+      }
+      const { messages } = getChatNodeMessages(inputData);
       setMessages({
         messages,
       });


### PR DESCRIPTION
- Adds error toast when prompt designer fails to run (eg. if there are too many tokens).
- Fixes split node loading for Prompt Designer, so that only the first node is loaded. This is what caused me to add the error toast, because I was loading 10 inputs into a split node.

![Screenshot 2023-06-14 at 9 14 18 AM](https://github.com/Ironclad/rivet/assets/448108/243f94c8-7725-40fe-a97a-5722826b9b52)
