### PR TITLE
Show error message for Trivet tests

### DIFF
--- a/packages/app/src/components/trivet/TestCaseEditor.tsx
+++ b/packages/app/src/components/trivet/TestCaseEditor.tsx
@@ -16,6 +16,10 @@ const styles = css`
   .editor-container {
     min-height: 200px;
   }
+
+  .testCaseError pre {
+    white-space: pre-wrap;
+  }
 `;
 
 export const TestCaseEditor: FC = () => {
@@ -66,6 +70,15 @@ export const TestCaseEditor: FC = () => {
           <InputOutputEditor
             json={testCaseResults.outputs ?? {}}
           />
+        </div>
+      )}
+      {testCaseResults?.error != null && (
+        <div className="testCaseError">
+          <label>Error</label>
+          <pre>
+            {testCaseResults.error.message ?? testCaseResults.error}
+            {testCaseResults.error.stack ?? ''}
+          </pre>
         </div>
       )}
     </div>

--- a/packages/trivet/src/trivetTypes.ts
+++ b/packages/trivet/src/trivetTypes.ts
@@ -43,6 +43,7 @@ export interface TrivetTestCaseResult {
   passing: boolean;
   message: string;
   outputs: Record<string, unknown>;
+  error?: Error | string | any;
 }
 
 export type TrivetData = {


### PR DESCRIPTION
Quick fix for showing error messages in Trivet.

Looks a bit janky, but makes it a lot easier to know what's going wrong.