### PR TITLE
Object node supports many data types

### DIFF
--- a/packages/app/src/hooks/useContextMenuAddNodeConfiguration.ts
+++ b/packages/app/src/hooks/useContextMenuAddNodeConfiguration.ts
@@ -403,7 +403,9 @@ export const addContextMenuGroups = [
           description: dedent`
             Creates an object from input values and a JSON template, escaping the input values and inserting them into the template.
 
-            Useful for creating objects from multiple string inputs.
+            Use double-quotes around the input values to escape them. String values are automatically escaped.
+
+            Useful for creating objects from multiple inputs.
           `,
         },
       },

--- a/packages/core/src/model/nodes/ObjectNode.ts
+++ b/packages/core/src/model/nodes/ObjectNode.ts
@@ -1,7 +1,6 @@
 import { ChartNode, NodeConnection, NodeId, NodeInputDefinition, NodeOutputDefinition, PortId } from '../NodeBase.js';
 import { nanoid } from 'nanoid';
 import { EditorDefinition, NodeImpl, nodeDefinition } from '../NodeImpl.js';
-import { coerceTypeOptional } from '../../utils/coerceType.js';
 import { DataValue } from '../DataValue.js';
 
 export type ObjectNode = ChartNode<'object', ObjectNodeData>;
@@ -72,20 +71,30 @@ export class ObjectNodeImpl extends NodeImpl<ObjectNode> {
   }
 
   interpolate(baseString: string, values: Record<string, any>): string {
-    return baseString.replace(/"?\{\{([^}]+)\}\}"?/g, (_m, p1) => {
-      const value = values[p1];
-      return value !== undefined ? value.toString() : '';
+    return baseString.replace(/("?)\{\{([^}]+)\}\}("?)/g, (_m, openQuote, key, _closeQuote) => {
+      const isQuoted = Boolean(openQuote);
+      const value = values[key];
+      if (value == null) {
+        return 'null';
+      }
+      if (isQuoted && typeof value === 'string') {
+        // Adds double-quotes back.
+        return JSON.stringify(value);
+      }
+      if (isQuoted) {
+        // Non-strings require a double-stringify, first to turn them into a string, then to escape that string and add quotes.
+        return JSON.stringify(JSON.stringify(value));
+      }
+      // Otherwise, it was not quoted, so no need to double-stringify
+      return JSON.stringify(value);
     });
   }
 
   async process(inputs: Record<string, DataValue>): Promise<Record<string, DataValue>> {
     const inputMap = Object.keys(inputs).reduce((acc, key) => {
-      const stringValue = coerceTypeOptional(inputs[key], 'string');
-
-      // Make string JSON-safe.
-      acc[key] = stringValue != null ? JSON.stringify(stringValue) : undefined;
+      acc[key] = (inputs[key] as any).value;
       return acc;
-    }, {} as Record<string, string | undefined>);
+    }, {} as Record<string, any>);
 
     const outputValue = JSON.parse(this.interpolate(this.chartNode.data.jsonTemplate, inputMap)) as Record<
       string,

--- a/packages/core/test/model/nodes/ObjectNode.test.ts
+++ b/packages/core/test/model/nodes/ObjectNode.test.ts
@@ -1,0 +1,123 @@
+import { it, describe, mock } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { DataValue, ObjectNode, ObjectNodeImpl } from '../../../src/index.js';
+
+const createNode = (data: Partial<ObjectNode['data']>) => {
+  return new ObjectNodeImpl({
+    ...ObjectNodeImpl.create(),
+    data: {
+      ...ObjectNodeImpl.create().data,
+      ...data,
+    },
+  });
+};
+
+describe('ObjectNodeImpl', () => {
+  it('can create node', () => {
+    const node = ObjectNodeImpl.create();
+    assert.strictEqual(node.type, 'object');
+  });
+
+  it('supports strings with quote characters', async () => {
+    const node = createNode({ jsonTemplate: `{"key": "{{input}}"}` });
+    const inputs: Record<string, DataValue> = {
+      input: { type: 'string', value: 'You say "goodbye," I say "hello."' },
+    };
+    const result = await node.process(inputs);
+    assert.deepStrictEqual(result['output'].value, { key: 'You say "goodbye," I say "hello."' });
+  });
+
+  it('supports strings strings without quote characters', async () => {
+    // Note lack of double-quotes around {{inputs}}
+    const node = createNode({ jsonTemplate: `{"key": {{input}} }` });
+    const inputs: Record<string, DataValue> = {
+      input: { type: 'string', value: 'You say "goodbye," I say "hello."' },
+    };
+    const result = await node.process(inputs);
+    assert.deepStrictEqual(result['output'].value, { key: 'You say "goodbye," I say "hello."' });
+  });
+
+  it('turns any key surrounded by double-quotes into escaped strings', async () => {
+    const node = createNode({ jsonTemplate: `{"key": "{{input}}"}` });
+    const inputs: Record<string, DataValue> = {
+      input: { type: 'object', value: { you: 'goodbye', me: 'hello' } },
+    };
+    const result = await node.process(inputs);
+
+    const keyValue = (result['output'].value as any)['key'];
+    assert.strictEqual(typeof keyValue, 'string');
+    assert.deepStrictEqual(JSON.parse(keyValue), { you: 'goodbye', me: 'hello' });
+  });
+
+  it('does not escape objects', async () => {
+    const node = createNode({ jsonTemplate: `{"key": {{input}}}` });
+    const inputs: Record<string, DataValue> = {
+      input: { type: 'object', value: { you: 'goodbye', me: 'hello' } },
+    };
+    const result = await node.process(inputs);
+
+    assert.deepEqual(result['output'].value, { key: { you: 'goodbye', me: 'hello' } });
+  });
+
+  it('does not escape booleans', async () => {
+    const node = createNode({ jsonTemplate: `{"key": {{input}}, "anotherKey": {{anotherInput}}}` });
+    const inputs: Record<string, DataValue> = {
+      input: { type: 'boolean', value: false },
+      anotherInput: { type: 'boolean', value: true },
+    };
+    const result = await node.process(inputs);
+
+    assert.deepStrictEqual(result['output'].value, { key: false, anotherKey: true });
+  });
+
+  it('does not escape numbers', async () => {
+    const node = createNode({ jsonTemplate: `{"key": {{input}}, "anotherKey": {{anotherInput}}}` });
+    const inputs: Record<string, DataValue> = {
+      input: { type: 'number', value: 0 },
+      anotherInput: { type: 'number', value: 2 },
+    };
+    const result = await node.process(inputs);
+
+    assert.deepStrictEqual(result['output'].value, { key: 0, anotherKey: 2 });
+  });
+
+  it('does not escape arrays', async () => {
+    const node = createNode({ jsonTemplate: `{"numArray": {{numArray}}, "strArray": {{strArray}}, "anyArray": {{anyArray}}, "objArray": {{objArray}}}` });
+    const inputs: Record<string, DataValue> = {
+      numArray: { type: 'number[]', value: [1, 2, 3] },
+      strArray: { type: 'string[]', value: ['hello'] },
+      anyArray: { type: 'any[]', value: ['world'] },
+      objArray: { type: 'object[]', value: [] },
+    };
+    const result = await node.process(inputs);
+
+    assert.deepEqual(result['output'].value, {
+      numArray: [1, 2, 3],
+      strArray: ['hello'],
+      anyArray: ['world'],
+      objArray: [],
+    });
+  });
+
+  it('allows variables to be used multiple times, both escaped and unescaped', async () => {
+    const node = createNode({ jsonTemplate: `{
+      "obj": {{obj}},
+      "objStr": "{{obj}}",
+      "nested": {
+        "obj": {{obj}}
+      }
+    }` });
+    const inputs: Record<string, DataValue> = {
+      obj: { type: 'object', value: { hello: 'world' } },
+    };
+    const result = await node.process(inputs);
+
+    assert.deepStrictEqual(result['output'].value, {
+      obj: { hello: 'world' },
+      objStr: '{"hello":"world"}',
+      nested: {
+        obj: { hello: 'world' },
+      },
+    });
+  })
+})


### PR DESCRIPTION
Enhances the object node, so that it supports more than just strings. Uses double-quotes (`"`) to indicate that a value should be treated as a string.

![Screenshot 2023-08-02 at 8 53 15 AM](https://github.com/Ironclad/rivet/assets/448108/b24a4bd6-1306-455c-b7cd-d39277e7b0ad)

Also, tests 🙌