### PR TITLE
Fix issue with split object node

### DIFF
--- a/packages/core/src/model/nodes/ObjectNode.ts
+++ b/packages/core/src/model/nodes/ObjectNode.ts
@@ -92,7 +92,7 @@ export class ObjectNodeImpl extends NodeImpl<ObjectNode> {
 
   async process(inputs: Record<string, DataValue>): Promise<Record<string, DataValue>> {
     const inputMap = Object.keys(inputs).reduce((acc, key) => {
-      acc[key] = (inputs[key] as any).value;
+      acc[key] = (inputs[key] as any)?.value;
       return acc;
     }, {} as Record<string, any>);
 

--- a/packages/core/test/model/nodes/ObjectNode.test.ts
+++ b/packages/core/test/model/nodes/ObjectNode.test.ts
@@ -119,5 +119,14 @@ describe('ObjectNodeImpl', () => {
         obj: { hello: 'world' },
       },
     });
-  })
+  });
+
+  it('supports fully undefined inputs', async () => {
+    const node = createNode({ jsonTemplate: `{"key": "{{input}}"}` });
+    const inputs: Record<string, DataValue> = {
+      input: undefined as any, // I believe this can happen when a split node has arrays of different lengths.
+    };
+    const result = await node.process(inputs);
+    assert.deepStrictEqual(result['output'].value, { key: null });
+  });
 })


### PR DESCRIPTION
It appears that inputs can be entirely undefined (not just `{ type: 'any', value: undefined }`), if an object node is a split and input arrays have different lengths. Guards against this in the object node.