### PR TITLE
Do not emit trailing slashes in docusaurus

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -25,6 +25,8 @@ const config = {
     locales: ['en'],
   },
 
+  trailingSlash: false,
+
   presets: [
     [
       'classic',


### PR DESCRIPTION
Certain docs, e.g. https://rivet.ironcladapp.com/trivet, use relative URLs. Docusaurus will (occasionally) add a trailing slash to links when you load them; however, [trailing slashes break](https://docusaurus.io/docs/markdown-features/links) relative links.

This change simply specifies the `trailingSlash` in the Docusaurus config to avoid this scenario. It may be a more robust approach to rework all relative links to absolute.