### PR TITLE
Set a key for items in TestCaseTable

### DIFF
--- a/packages/app/src/components/trivet/TestCaseTable.tsx
+++ b/packages/app/src/components/trivet/TestCaseTable.tsx
@@ -220,7 +220,7 @@ export const TestCaseTable: FC<TestCaseTableProps> = ({
         <div className="cell header-cell">Outputs</div>
 
         {testCases.map((testCase) => (
-          <div className={clsx('test-case-row-container', { selected: editingTestCaseId === testCase.id })}>
+          <div key={testCase.id} className={clsx('test-case-row-container', { selected: editingTestCaseId === testCase.id })}>
             <div className="cell selected-cell-indicator" />
             <div className="cell nobg">
               <button className="run-test-button" onClick={() => onRunTestCase(testCase.id)}>


### PR DESCRIPTION
I noticed (via console error) that the cases in a `TestCaseTable` were missing their `key` property.