### PR TITLE
External functions can return cost estimates

### DIFF
--- a/packages/core/src/model/GraphProcessor.ts
+++ b/packages/core/src/model/GraphProcessor.ts
@@ -113,7 +113,7 @@ export type Outputs = Record<PortId, DataValue | undefined>;
 
 export type ExternalFunctionProcessContext = Omit<InternalProcessContext, 'setGlobal'>;
 
-export type ExternalFunction = (context: ExternalFunctionProcessContext, ...args: unknown[]) => Promise<DataValue>;
+export type ExternalFunction = (context: ExternalFunctionProcessContext, ...args: unknown[]) => Promise<DataValue & { cost?: number }>;
 
 type RaceId = Opaque<string, 'RaceId'>;
 

--- a/packages/core/src/model/nodes/ExternalCallNode.ts
+++ b/packages/core/src/model/nodes/ExternalCallNode.ts
@@ -138,6 +138,10 @@ export class ExternalCallNodeImpl extends NodeImpl<ExternalCallNode> {
         const result = await fn(externalContext, ...arrayArgs.value);
         return {
           ['result' as PortId]: result,
+          ['cost' as PortId]: {
+            type: 'number',
+            value: result.cost ?? 0,
+          },
           ['error' as PortId]: {
             type: 'control-flow-excluded',
             value: undefined,


### PR DESCRIPTION
Allows external functions to include a cost estimate in their return value, which will be aggregated with the total cost estimate.