### PR TITLE
RFC: Abort external calls early

### DIFF
--- a/packages/core/src/utils/promises.ts
+++ b/packages/core/src/utils/promises.ts
@@ -1,0 +1,11 @@
+export function abortablePromise<T>(p: Promise<T> | (() => Promise<T>), signal: AbortSignal): Promise<T> {
+  return new Promise((resolve, reject) => {
+    signal.addEventListener('abort', () => {
+      reject(new Error('Aborted'));
+    });
+    if (typeof p === 'function') {
+      p = p();
+    }
+    p.then(resolve, reject);
+  });
+}

--- a/packages/core/test/model/GraphProcessor.test.RaceInputNode.rivet-project
+++ b/packages/core/test/model/GraphProcessor.test.RaceInputNode.rivet-project
@@ -1,0 +1,34 @@
+version: 4
+data:
+  attachedData:
+    trivet:
+      testSuites: []
+      version: 1
+  graphs:
+    9ilbaCrzWHBbEzmHZLMno:
+      metadata:
+        description: ""
+        id: 9ilbaCrzWHBbEzmHZLMno
+        name: Race Input Test
+      nodes:
+        '[JSa_us_WmxdvOEOFl9PoD]:raceInputs "Race Inputs"':
+          visualData: 771/278/300/4
+        '[OQHQHvRHxSxHnW4TIfP6Q]:text "Text"':
+          data:
+            text: Test
+          outgoingConnections:
+            - output->"External Call" xxce_OYKA3nWRQrcMevP_/arguments
+            - output->"Race Inputs" JSa_us_WmxdvOEOFl9PoD/input2
+          visualData: -205/279/300/2
+        '[xxce_OYKA3nWRQrcMevP_]:externalCall "External Call"':
+          data:
+            functionName: wait
+            useErrorOutput: false
+            useFunctionNameInput: false
+          outgoingConnections:
+            - result->"Race Inputs" JSa_us_WmxdvOEOFl9PoD/input1
+          visualData: 374/168/150/5
+  metadata:
+    description: ""
+    id: vBl2lCqPRsM10D0Tfta4J
+    title: Untitled Project

--- a/packages/core/test/model/GraphProcessor.test.ts
+++ b/packages/core/test/model/GraphProcessor.test.ts
@@ -1,0 +1,33 @@
+import { it, describe, mock } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { GraphId, GraphProcessor, deserializeProject } from '../../src/index.js';
+
+describe('GraphProcessor', () => {
+  describe('RaceInputsNode', () => {
+    it('should abort long-running nodes', async () => {
+      try {
+        const content = await readFile('test/model/GraphProcessor.test.RaceInputNode.rivet-project', { encoding: 'utf8' });
+        const [project] = deserializeProject(content);
+        const processor = new GraphProcessor(project, '9ilbaCrzWHBbEzmHZLMno' as GraphId);
+        processor.setExternalFunction('wait', async () => new Promise(resolve => setTimeout(resolve, 3000)));
+        const startTime = Date.now();
+        await processor.processGraph({
+          settings: {
+            openAiKey: 'NONE',
+          },
+          nativeApi: {
+            readdir: mock.fn(async () => ([])),
+            readTextFile: mock.fn(async () => 'test'),
+            readBinaryFile: mock.fn(async () => new Blob([])),
+            writeTextFile: mock.fn(async () => {}),
+          }
+        });
+        const duration = Date.now() - startTime;
+        assert.ok(duration < 1000, 'Expected long-running node to abort immediately');
+      } catch (err) {
+        assert.fail(err);
+      }
+    })
+  });
+});


### PR DESCRIPTION
Aborts external call nodes early, using a technique we could extend to other nodes (eg. Wait For Event, Chat, or even an async Code node if we choose).

"RFC," because this isn't actually the issue I was running into, which I fixed with #62. It feels like someone will run into it at some point, but I'm always hesitant about prematurely fixing an issue like this.