### PR TITLE
Add LeMUR Summary node

### DIFF
--- a/packages/app/src/hooks/useContextMenuAddNodeConfiguration.ts
+++ b/packages/app/src/hooks/useContextMenuAddNodeConfiguration.ts
@@ -2,6 +2,7 @@ import { NodeUIData, globalRivetNodeRegistry } from '@ironclad/rivet-core';
 import { ContextMenuItem } from './useContextMenuConfiguration';
 import { useMemo } from 'react';
 import { useBuiltInNodeImages } from './useBuiltInNodeImages';
+import { useDependsOnPlugins } from './useDependsOnPlugins';
 
 export const addContextMenuGroups = [
   {
@@ -62,17 +63,21 @@ export function useContextMenuAddNodeConfiguration() {
     const uiData = constructor.getUIData
       ? constructor.getUIData()
       : ({
-          group: 'Custom',
-          contextMenuTitle: type,
-          infoBoxTitle: type,
-          infoBoxBody: '',
-        } satisfies NodeUIData);
+        group: 'Custom',
+        contextMenuTitle: type,
+        infoBoxTitle: type,
+        infoBoxBody: '',
+      } satisfies NodeUIData);
 
     return { type, uiData };
   });
 
+  const plugins = useDependsOnPlugins();
   const groupsWithItems = useMemo(() => {
-    const groups = addContextMenuGroups.map((group) => {
+    const groups = ([
+      ...addContextMenuGroups,
+      ...plugins.flatMap(plugin => plugin.contextMenuGroups ?? [])
+    ]).map((group) => {
       const items = uiData
         .filter((item) =>
           Array.isArray(item.uiData.group)

--- a/packages/core/src/model/RivetPlugin.ts
+++ b/packages/core/src/model/RivetPlugin.ts
@@ -8,6 +8,11 @@ export type RivetPlugin = {
 
   /** The available configuration items and their specification, for configuring a plugin in the UI. */
   configSpec?: RivetPluginConfigSpecs;
+
+  contextMenuGroups?: Array<{
+    id: string;
+    label: string;
+  }>;
 };
 
 export type RivetPluginConfigSpecs = Record<string, PluginConfigurationSpec>;

--- a/packages/core/src/plugins/assemblyAi/LeMURSummaryNode.ts
+++ b/packages/core/src/plugins/assemblyAi/LeMURSummaryNode.ts
@@ -110,7 +110,7 @@ export class LeMURSummaryNodeImpl extends NodeImpl<LeMURSummaryNode> {
       infoBoxBody: dedent`Use AssemblyAI LeMUR Summary to apply LLM tasks to audio`,
       infoBoxTitle: 'Use AssemblyAI LeMUR Summary',
       contextMenuTitle: 'LeMUR Summary',
-      group: 'AI',
+      group: ['AI', 'AssemblyAI'],
     };
   }
 

--- a/packages/core/src/plugins/assemblyAi/TranscribeAudioNode.ts
+++ b/packages/core/src/plugins/assemblyAi/TranscribeAudioNode.ts
@@ -78,7 +78,7 @@ export class TranscribeAudioNodeImpl extends NodeImpl<TranscribeAudioNode> {
       infoBoxBody: dedent`Use AssemblyAI to transcribe audio`,
       infoBoxTitle: 'Transcribe Audio Node',
       contextMenuTitle: 'Transcribe Audio',
-      group: 'AI',
+      group: ['AI', 'AssemblyAI'],
     };
   }
 

--- a/packages/core/src/plugins/assemblyAi/plugin.ts
+++ b/packages/core/src/plugins/assemblyAi/plugin.ts
@@ -17,4 +17,11 @@ export const assemblyAiPlugin: RivetPlugin = {
       pullEnvironmentVariable: 'ASSEMBLYAI_API_KEY',
     },
   },
+
+  contextMenuGroups: [
+    {
+      id: 'add-node-group:assemblyai',
+      label: 'AssemblyAI',
+    }
+  ]
 };


### PR DESCRIPTION
This PR updates the Transcribe Audio Node and adds the LeMUR summary node.
LeMUR has [other endpoints](https://www.assemblyai.com/docs/API%20reference/lemur) such as Q&A, custom task, etc. which have different input and output, so I think it makes the most sense to have a different node for each LeMUR endpoint.

It would be great if we could add our own category of "AssemblyAI" or "LeMUR" or "Audio" to group these nodes together.

What do y'all think?

Here's how I built the graph combining the different nodes together.
<img width="805" alt="Screenshot 2023-08-22 at 3 07 49 PM" src="https://github.com/Ironclad/rivet/assets/3382717/2bb2a9a6-30f7-4d1a-8478-7801d4c5046a">


