### PR TITLE
Add Ironclad logo alt text

### DIFF
--- a/packages/docs/src/components/main/IroncladContractAiSection.tsx
+++ b/packages/docs/src/components/main/IroncladContractAiSection.tsx
@@ -23,7 +23,7 @@ export const IroncladContractAiSection: React.FC<{ id?: string }> = ({ id }) => 
   return (
     <Section id={id}>
       <h2 className={styles.title}>
-        <img className={styles.inlineLogo} src="img/ironclad-logo-white.png" height="24px" /> Contract AI
+        <img alt="Ironclad" className={styles.inlineLogo} src="img/ironclad-logo-white.png" height="24px" /> Contract AI
       </h2>
       <p>
         Ironclad Contract AI (CAI) is a virtual contract assistant, powered by AI agents, and developed with Rivet. CAI

--- a/packages/docs/src/components/main/WhatIsRivetSection.tsx
+++ b/packages/docs/src/components/main/WhatIsRivetSection.tsx
@@ -19,7 +19,7 @@ export const WhatIsRivetSection: React.FC<{ id?: string }> = ({ id }) => {
           graphs.
         </p>
         <p>
-          <img className={styles.inlineLogo} src="img/ironclad-logo.png" height="16px" /> is the leading digital
+          <img alt="Ironclad" className={styles.inlineLogo} src="img/ironclad-logo.png" height="16px" /> is the leading digital
           contracting platform.
           {' '}
           <a href="https://ironcladapp.com/product/ai-based-contract-management/" target="_blank">Ironclad AI</a>
@@ -28,7 +28,7 @@ export const WhatIsRivetSection: React.FC<{ id?: string }> = ({ id }) => {
           {' '}
           Learn more at <a href="https://www.ironcladapp.com/" target="_blank">ironcladapp.com</a>.
         </p>
-        <p>Rivet is built and used by <img className={styles.inlineLogo} src="img/ironclad-logo.png" height="16px" /> Research.</p>
+        <p>Rivet is built and used by <img alt="Ironclad" className={styles.inlineLogo} src="img/ironclad-logo.png" height="16px" /> Research.</p>
       </div>
     </Section>
   );


### PR DESCRIPTION
The logo is used as a replacement for the company name so the alt text should reflect that accordingly 