### PR TITLE
Make pinecone integration a plugin

### DIFF
--- a/packages/app/src/components/SettingsModal.tsx
+++ b/packages/app/src/components/SettingsModal.tsx
@@ -31,7 +31,7 @@ const modalBody = css`
   }
 
   main {
-    padding: 0 30px;
+    padding: 0 30px 30px 30px;
   }
 `;
 

--- a/packages/core/src/model/Settings.ts
+++ b/packages/core/src/model/Settings.ts
@@ -13,7 +13,6 @@ export interface Settings<PluginSettings = Record<string, Record<string, unknown
   openAiKey: string;
   openAiOrganization?: string;
 
-  // pineconeApiKey?: string;
   // anthropicApiKey?: string;
   // assemblyAiApiKey?: string;
 

--- a/packages/core/src/plugins.ts
+++ b/packages/core/src/plugins.ts
@@ -2,12 +2,14 @@ import anthropicPlugin from './plugins/anthropic/index.js';
 import autoevalsPlugin from './plugins/autoevals/index.js';
 import assemblyAiPlugin from './plugins/assemblyAi/index.js';
 import { huggingFacePlugin } from './plugins/huggingface/plugin.js';
+import pineconePlugin from './plugins/pinecone/index.js';
 
-export { anthropicPlugin, autoevalsPlugin, assemblyAiPlugin, huggingFacePlugin };
+export { anthropicPlugin, autoevalsPlugin, assemblyAiPlugin, pineconePlugin, huggingFacePlugin };
 
 export const plugins = {
   anthropic: anthropicPlugin,
   autoevals: autoevalsPlugin,
   assemblyAi: assemblyAiPlugin,
+  pinecone: pineconePlugin,
   huggingFace: huggingFacePlugin,
 };

--- a/packages/core/src/plugins/pinecone/PineconeVectorDatabase.ts
+++ b/packages/core/src/plugins/pinecone/PineconeVectorDatabase.ts
@@ -7,21 +7,7 @@ import {
   VectorDatabase,
   coerceType,
 } from '@ironclad/rivet-core';
-
-async function sha256(message: string): Promise<string> {
-  // encode as UTF-8
-  const msgBuffer = new TextEncoder().encode(message);
-
-  // hash the message
-  const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
-
-  // convert ArrayBuffer to Array
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-
-  // convert bytes to hex string
-  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-  return hashHex;
-}
+import * as CryptoJS from 'crypto-js';
 
 export class PineconeVectorDatabase implements VectorDatabase {
   #apiKey;
@@ -34,7 +20,7 @@ export class PineconeVectorDatabase implements VectorDatabase {
     const collectionDetails = getCollection(coerceType(collection, 'string'));
 
     if (!id) {
-      id = await sha256(vector.value.join(','));
+      id = CryptoJS.SHA256(vector.value.join(',')).toString(CryptoJS.enc.Hex);
     }
 
     const response = await fetch(`${collectionDetails.host}/vectors/upsert`, {

--- a/packages/core/src/plugins/pinecone/index.ts
+++ b/packages/core/src/plugins/pinecone/index.ts
@@ -1,0 +1,3 @@
+import { pineconePlugin } from './plugin.js';
+
+export default pineconePlugin;

--- a/packages/core/src/plugins/pinecone/plugin.ts
+++ b/packages/core/src/plugins/pinecone/plugin.ts
@@ -1,0 +1,21 @@
+import { registerIntegration, RivetPlugin } from '../../index.js';
+import { PineconeVectorDatabase } from './PineconeVectorDatabase.js';
+
+export const pineconePlugin: RivetPlugin = {
+  id: 'pinecone',
+  name: 'Pinecone',
+
+  register: () => {
+    registerIntegration('vectorDatabase', 'pinecone', (context) => new PineconeVectorDatabase(context.settings));
+  },
+
+  configSpec: {
+    pineconeApiKey: {
+      type: 'secret',
+      label: 'Pinecone API Key',
+      description: 'The API key for the Pinecone service.',
+      pullEnvironmentVariable: 'PINECONE_API_KEY',
+      helperText: 'You may also set the PINECONE_API_KEY environment variable.',
+    },
+  },
+};

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -3,5 +3,3 @@ export * from '@ironclad/rivet-core';
 export * from './native/NodeNativeApi.js';
 export * from './api.js';
 export * from './debugger.js';
-
-import './integrations/registerNodeIntegrations.js';

--- a/packages/node/src/integrations/registerNodeIntegrations.ts
+++ b/packages/node/src/integrations/registerNodeIntegrations.ts
@@ -1,4 +1,0 @@
-import { registerIntegration } from '@ironclad/rivet-core';
-import { PineconeVectorDatabase } from './pinecone/PineconeVectorDatabase.js';
-
-registerIntegration('vectorDatabase', 'pinecone', (context) => new PineconeVectorDatabase(context.settings));


### PR DESCRIPTION
Migrates the pinecone DB integration a plugin. This allows it to be loaded dynamically, and the API key to be configured via the settings interface.

Also makes the collection handling a bit more robust to the format provided on the Pinecone UI.