### PR TITLE
Provide transcript ID as output of transcribe node

### DIFF
--- a/packages/core/src/plugins/assemblyAi/LemurQaNode.ts
+++ b/packages/core/src/plugins/assemblyAi/LemurQaNode.ts
@@ -126,7 +126,7 @@ export class LemurQaNodeImpl extends NodeImpl<LemurQaNode> {
       | ArrayDataValue<ObjectDataValue>
       | ArrayDataValue<AnyDataValue>;
 
-    if (!input) throw new Error('Transcript IDs are required.');
+    if (!input) throw new Error('Questions are required.');
 
     if (input.type === 'string') {
       return [{

--- a/packages/core/src/plugins/assemblyAi/TranscribeAudioNode.ts
+++ b/packages/core/src/plugins/assemblyAi/TranscribeAudioNode.ts
@@ -58,6 +58,11 @@ export class TranscribeAudioNodeImpl extends NodeImpl<TranscribeAudioNode> {
         title: 'Transcript text',
       },
       {
+        dataType: 'string',
+        id: 'id' as PortId,
+        title: 'Transcript ID',
+      },
+      {
         dataType: 'object',
         id: 'transcript' as PortId,
         title: 'Transcript object',
@@ -111,10 +116,14 @@ export class TranscribeAudioNodeImpl extends NodeImpl<TranscribeAudioNode> {
         type: 'string',
         value: transcript.text,
       },
+      ['id' as PortId]: {
+        type: 'string',
+        value: transcript.id,
+      },
       ['transcript' as PortId]: {
         type: 'object',
         value: transcript,
-      },
+      }
     };
   }
 }


### PR DESCRIPTION
Since the LeMUR node take in the transcript ID, it's more convenient for the transcribe node to provide this ID as an output.
Previously, I used the object path selector, which now wouldn't be necessary anymore.