### PR TITLE
Make `openAiKey` optional

### DIFF
--- a/packages/core/src/model/Settings.ts
+++ b/packages/core/src/model/Settings.ts
@@ -10,7 +10,7 @@ export interface Settings<PluginSettings = Record<string, Record<string, unknown
   };
 
   // TODO move to openai plugin
-  openAiKey: string;
+  openAiKey?: string;
   openAiOrganization?: string;
 
   // anthropicApiKey?: string;

--- a/packages/core/src/model/nodes/ChatNode.ts
+++ b/packages/core/src/model/nodes/ChatNode.ts
@@ -478,7 +478,10 @@ export class ChatNodeImpl extends NodeImpl<ChatNode> {
           }
 
           const startTime = Date.now();
-
+          if (!context.settings.openAiKey) {
+            throw new Error("OpenAI key must be configured.");
+          }
+          
           const chunks = streamChatCompletions({
             auth: {
               apiKey: context.settings.openAiKey,

--- a/packages/node/src/api.ts
+++ b/packages/node/src/api.ts
@@ -56,8 +56,8 @@ export type RunGraphOptions = {
   abortSignal?: AbortSignal;
   registry?: NodeRegistration;
 } & {
-  [P in keyof ProcessEvents as `on${PascalCase<P>}`]?: (params: ProcessEvents[P]) => void;
-} & Settings;
+    [P in keyof ProcessEvents as `on${PascalCase<P>}`]?: (params: ProcessEvents[P]) => void;
+  } & Settings;
 
 export async function runGraphInFile(path: string, options: RunGraphOptions): Promise<Record<string, DataValue>> {
   const project = await loadProjectFromFile(path);
@@ -193,7 +193,7 @@ export function createProcessor(project: Project, options: RunGraphOptions) {
         {
           nativeApi: options.nativeApi ?? new NodeNativeApi(),
           settings: {
-            openAiKey: options.openAiKey,
+            openAiKey: options.openAiKey ?? '',
             openAiOrganization: options.openAiOrganization ?? '',
             pluginEnv: options.pluginEnv ?? {},
             pluginSettings: options.pluginSettings ?? {},
@@ -227,8 +227,8 @@ function getPluginEnvFromProcessEnv(registry?: NodeRegistration) {
           typeof config.pullEnvironmentVariable === 'string'
             ? config.pullEnvironmentVariable
             : config.pullEnvironmentVariable === true
-            ? configName
-            : undefined;
+              ? configName
+              : undefined;
         if (envVarName) {
           pluginEnv[envVarName] = process.env[envVarName] ?? '';
         }


### PR DESCRIPTION
While OpenAI was probably the focus of Rivet originally, not all Rivet projects will use OpenAI so I propose making the `openAiKey` field optional.