### PR TITLE
make node editor panel async for fetching editor settings dynamically

### DIFF
--- a/packages/app/src/components/DefaultNodeEditor.tsx
+++ b/packages/app/src/components/DefaultNodeEditor.tsx
@@ -1,4 +1,4 @@
-import { FC, Suspense, useEffect, useMemo, useRef } from 'react';
+import { FC, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AnyDataEditorDefinition,
   ChartNode,
@@ -125,7 +125,16 @@ export const DefaultNodeEditor: FC<{
   isReadonly: boolean;
   onChange: NodeChanged;
 }> = ({ node, onChange, isReadonly }) => {
-  const editors = useMemo(() => globalRivetNodeRegistry.createDynamicImpl(node).getEditors(), [node]);
+  
+  const [editors, setEditors] = useState<any[]>([]);
+  
+  useEffect(() => {
+    (async () => {
+      const dynamicImpl = globalRivetNodeRegistry.createDynamicImpl(node);
+      const loadedEditors = await dynamicImpl.getEditors();
+      setEditors(loadedEditors);
+    })();
+  }, [node]);
 
   return (
     <div css={defaultEditorContainerStyles}>

--- a/packages/core/src/model/NodeImpl.ts
+++ b/packages/core/src/model/NodeImpl.ts
@@ -46,7 +46,7 @@ export abstract class NodeImpl<T extends ChartNode, Type extends T['type'] = T['
 
   abstract process(inputData: Inputs, context: InternalProcessContext): Promise<Outputs>;
 
-  getEditors(): EditorDefinition<T>[] {
+  getEditors(): EditorDefinition<T>[]|Promise<EditorDefinition<T>[]> {
     return [];
   }
 


### PR DESCRIPTION
While building a plugin for Oobabooga integration, I needed to asynchronously load my model list from Oobabooga.  These changes make that possible, allowing me to fetch node editor settings asynchronously before rendering the node editor

Note that this method does remove the useMemo hook used to cache the editor panels, which has _not_ shown any performance hicups.