### PR TITLE
feat: Gentrace plugin addition: record events from remote debugger

### DIFF
--- a/packages/app/src/components/gentrace/GentracePipelinePicker.tsx
+++ b/packages/app/src/components/gentrace/GentracePipelinePicker.tsx
@@ -68,7 +68,7 @@ const GentracePipelinePicker: FC<GentracePipelinePickerProps> = ({ onClose }) =>
 
   const effectiveSelectedPipeline = selectedPipelineOption ?? currentOption ?? pipelineOptions[0] ?? null;
   
-  const onSave = () => {
+  const onAssociate = () => {
     if (!selectedPipelineOption) {
       return;
     }
@@ -94,7 +94,7 @@ const GentracePipelinePicker: FC<GentracePipelinePickerProps> = ({ onClose }) =>
     
     setSelectedPipeline(null);
     
-    toast.info(`Saved Gentrace Pipeline: ${selectedPipelineOption.label}`, { autoClose: 4000 });
+    toast.info(`Associated Gentrace pipeline: ${selectedPipelineOption.label}`, { autoClose: 4000 });
   };
 
   return (
@@ -139,8 +139,8 @@ const GentracePipelinePicker: FC<GentracePipelinePickerProps> = ({ onClose }) =>
           height: 32px;
           border-radius: 5px;
           background: ${selectedPipelineOption ? "var(--success)" : "var(--grey-darker)"};
-        `} disabled={!selectedPipelineOption} onClick={onSave}>
-          Save
+        `} disabled={!selectedPipelineOption} onClick={onAssociate}>
+          Associate
         </button>
       </div>
       

--- a/packages/app/src/components/gentrace/GentracePipelinePicker.tsx
+++ b/packages/app/src/components/gentrace/GentracePipelinePicker.tsx
@@ -79,13 +79,15 @@ const GentracePipelinePicker: FC<GentracePipelinePickerProps> = ({ onClose }) =>
       return;
     }
 
+    const { cases, ...selectedPipelineNoCases } = selectedPipeline;
+
     setGraph({ 
       ...graph, 
       metadata: { 
         ...graph.metadata, 
         attachedData: { 
           ...(graph.metadata?.attachedData ?? {}), 
-          gentracePipeline: selectedPipeline
+          gentracePipeline: selectedPipelineNoCases
         } 
       } 
     });

--- a/packages/app/src/hooks/useRemoteDebugger.ts
+++ b/packages/app/src/hooks/useRemoteDebugger.ts
@@ -27,7 +27,6 @@ export function useRemoteDebugger(options: { onConnect?: () => void; onDisconnec
       url = `ws://localhost:21888`;
     }
     const socket = new WebSocket(url);
-
     onConnectLatest.current?.();
 
     setRemoteDebuggerState((prevState) => ({

--- a/packages/app/src/hooks/useRemoteDebugger.ts
+++ b/packages/app/src/hooks/useRemoteDebugger.ts
@@ -27,6 +27,7 @@ export function useRemoteDebugger(options: { onConnect?: () => void; onDisconnec
       url = `ws://localhost:21888`;
     }
     const socket = new WebSocket(url);
+
     onConnectLatest.current?.();
 
     setRemoteDebuggerState((prevState) => ({
@@ -71,6 +72,8 @@ export function useRemoteDebugger(options: { onConnect?: () => void; onDisconnec
 
     socket.onmessage = (event) => {
       const { message, data } = JSON.parse(event.data);
+      
+      console.log('message', message, 'data', data);
 
       if (message === 'graph-upload-allowed') {
         console.log('Graph uploading is allowed.');

--- a/packages/app/src/hooks/useRemoteDebugger.ts
+++ b/packages/app/src/hooks/useRemoteDebugger.ts
@@ -72,8 +72,6 @@ export function useRemoteDebugger(options: { onConnect?: () => void; onDisconnec
 
     socket.onmessage = (event) => {
       const { message, data } = JSON.parse(event.data);
-      
-      console.log('message', message, 'data', data);
 
       if (message === 'graph-upload-allowed') {
         console.log('Graph uploading is allowed.');

--- a/packages/core/src/plugins/gentrace/plugin.ts
+++ b/packages/core/src/plugins/gentrace/plugin.ts
@@ -102,7 +102,7 @@ export const runRemoteGentraceTests = async (
   settings: Settings,
   project: Omit<Project, 'data'>,
   graph: NodeGraph,
-  outputAndStepRetriever: (testCase: Record<string, any>) => Promise<Recording>,
+  runAndRecord: (testCase: Record<string, any>) => Promise<Recording>,
 ) => {
   const gentraceApiKey = settings.pluginSettings?.gentrace?.gentraceApiKey as string | undefined;
 
@@ -127,7 +127,7 @@ export const runRemoteGentraceTests = async (
 
     const rivetFormattedInputs = mapValues(testCase.inputs, inferType);
 
-    const fullRecording = await outputAndStepRetriever(rivetFormattedInputs);
+    const fullRecording = await runAndRecord(rivetFormattedInputs);
     const stepRuns = convertRecordingToStepRuns(fullRecording, project, graphId);
 
     stepRuns.forEach((stepRun) => {

--- a/packages/core/src/plugins/gentrace/plugin.ts
+++ b/packages/core/src/plugins/gentrace/plugin.ts
@@ -11,7 +11,9 @@ import {
   RivetPlugin,
   SecretPluginConfigurationSpec,
   Settings,
+  inferType,
 } from '../../index.js';
+import { mapValues } from 'lodash-es';
 
 const apiKeyConfigSpec: SecretPluginConfigurationSpec = {
   type: 'secret',
@@ -55,16 +57,7 @@ export const runGentraceTests = async (
 
     const runner = pipeline.start();
 
-    // Transform inputs
-    const rivetFormattedInputs: Record<string, any> = {};
-
-    Object.entries(testCase.inputs).forEach(([key, value]) => {
-      rivetFormattedInputs[key] = {
-        // Improve to fit Gentrace data types into the format that Rivet expects. Currently too naïve.
-        type: typeof value,
-        value,
-      };
-    });
+    const rivetFormattedInputs = mapValues(testCase.inputs, inferType);
 
     const tempProject = {
       ...project,
@@ -88,6 +81,53 @@ export const runGentraceTests = async (
 
     const fullRecording = recorder.getRecording();
 
+    const stepRuns = convertRecordingToStepRuns(fullRecording, project, graphId);
+
+    stepRuns.forEach((stepRun) => {
+      runner.addStepRunNode(stepRun);
+    });
+
+    if (stepRuns.length === 0) {
+      throw new Error('No Rivet steps found. You need operations which are not Graph Input or Graph Output nodes.');
+    }
+
+    return ['', runner];
+  });
+
+  return response;
+};
+
+export const runRemoteGentraceTests = async (
+  gentracePipelineSlug: string,
+  settings: Settings,
+  project: Omit<Project, 'data'>,
+  graph: NodeGraph,
+  outputAndStepRetriever: (testCase: Record<string, any>) => Promise<Recording>,
+) => {
+  const gentraceApiKey = settings.pluginSettings?.gentrace?.gentraceApiKey as string | undefined;
+
+  if (!gentraceApiKey) {
+    throw new Error('Gentrace API key not set.');
+  }
+
+  const graphId = graph.metadata?.id;
+
+  if (!graphId) {
+    throw new Error('Graph ID not set.');
+  }
+
+  initializeGentrace(gentraceApiKey);
+
+  const response = await runTest(gentracePipelineSlug, async (testCase) => {
+    const pipeline = new Pipeline({
+      slug: gentracePipelineSlug,
+    });
+
+    const runner = pipeline.start();
+
+    const rivetFormattedInputs = mapValues(testCase.inputs, inferType);
+
+    const fullRecording = await outputAndStepRetriever(rivetFormattedInputs);
     const stepRuns = convertRecordingToStepRuns(fullRecording, project, graphId);
 
     stepRuns.forEach((stepRun) => {

--- a/packages/core/src/recording/ExecutionRecorder.ts
+++ b/packages/core/src/recording/ExecutionRecorder.ts
@@ -143,8 +143,6 @@ export class ExecutionRecorder {
       const listener = (event: MessageEvent) => {
         const { message, data } = JSON.parse(event.data);
 
-        console.log('recording event', message, data);
-
         if (this.#options.includePartialOutputs === false && message === 'partialOutput') {
           return;
         }

--- a/packages/core/src/utils/serialization/serialization_v4.ts
+++ b/packages/core/src/utils/serialization/serialization_v4.ts
@@ -29,13 +29,15 @@ type SerializedProject = {
   plugins?: PluginLoadSpec[];
 };
 
-type SerializedGraph = {
-  metadata: {
-    id: GraphId;
-    name: string;
-    description: string;
-  };
+type SerializedGraphMetadata = {
+  id: GraphId;
+  name: string;
+  description: string;
+  attachedData?: AttachedData;
+};
 
+type SerializedGraph = {
+  metadata: SerializedGraphMetadata;
   nodes: Record<SerializedGraphNodeKey, SerializedNode>;
 };
 
@@ -145,12 +147,18 @@ function fromSerializedProject(serializedProject: SerializedProject): [Project, 
 }
 
 function toSerializedGraph(graph: NodeGraph): SerializedGraph {
+  const graphMetadata: SerializedGraphMetadata = {
+    id: graph.metadata!.id!,
+    name: graph.metadata!.name!,
+    description: graph.metadata!.description!,
+  };
+
+  if (graph.metadata!.attachedData) {
+    graphMetadata.attachedData = graph.metadata!.attachedData;
+  }
+
   return {
-    metadata: {
-      id: graph.metadata!.id!,
-      name: graph.metadata!.name!,
-      description: graph.metadata!.description!,
-    },
+    metadata: graphMetadata,
     nodes: graph.nodes.reduce(
       (acc, node) => ({
         ...acc,

--- a/packages/core/src/utils/serialization/serialization_v4.ts
+++ b/packages/core/src/utils/serialization/serialization_v4.ts
@@ -194,12 +194,18 @@ function fromSerializedGraph(serializedGraph: SerializedGraph): NodeGraph {
     allConnections.push(...connections);
   }
 
+  const metadata: SerializedGraphMetadata = {
+    id: serializedGraph.metadata.id,
+    name: serializedGraph.metadata.name,
+    description: serializedGraph.metadata.description,
+  };
+
+  if (serializedGraph.metadata.attachedData) {
+    metadata.attachedData = serializedGraph.metadata.attachedData;
+  }
+
   return {
-    metadata: {
-      id: serializedGraph.metadata.id,
-      name: serializedGraph.metadata.name,
-      description: serializedGraph.metadata.description,
-    },
+    metadata,
     nodes: allNodes,
     connections: allConnections,
   };


### PR DESCRIPTION
### Motivation

I created this PR to support tracing external calls to the remote debugger environment. We need this functionality to trace external calls that occur in the remote environment within Gentrace.

### Changelog

- Created a new `runRemoteGentraceTests()` function that's responsible for tracing the remote debugger instance. I followed the pattern for [how Trivet remotely invokes test/validation graphs](https://github.com/Ironclad/rivet/blob/44e9c5e5a80dc06ef03669d72e5faff53f1cf63f/packages/app/src/hooks/useRemoteExecutor.ts#L191)
- Created a `recordSocket()` on the `ExecutionRecorder` which records events from a WebSocket rather than a processor. We need this since we need to process all intermediate steps from the remote graph execution. Trivet currently only needs the output [which it gets from the debugger handler](https://github.com/Ironclad/rivet/blob/44e9c5e5a80dc06ef03669d72e5faff53f1cf63f/packages/app/src/hooks/useRemoteExecutor.ts#L68) in `useRemoteExecutor()`.

### Future enhancements

- @gogwilt pointed out that this [all feels hacky](https://github.com/Ironclad/rivet/blob/44e9c5e5a80dc06ef03669d72e5faff53f1cf63f/packages/app/src/hooks/useRemoteExecutor.ts#L24) and I definitely agree. If we had an ID associated with every (remote?) graph execution, we could create better abstractions to encapsulate events processed for the remote debugger. That would also allow us to invoke graph requests in parallel. 

Would love to have your feedback 😄 . Still loving Rivet! 