### PR TITLE
Fix UI Bugs

### DIFF
--- a/packages/app/src/components/NodeOutput.tsx
+++ b/packages/app/src/components/NodeOutput.tsx
@@ -461,14 +461,14 @@ const NodeOutputMultiProcess: FC<{
 
   const prevPage = useStableCallback(() => {
     setSelectedPage((page) => {
-      const pageNum = page === 'latest' ? data.length : page;
+      const pageNum = page === 'latest' ? data.length - 1 : page;
       return pageNum > 0 ? pageNum - 1 : pageNum;
     });
   });
 
   const nextPage = useStableCallback(() => {
     setSelectedPage((page) => {
-      const pageNum = page === 'latest' ? data.length : page;
+      const pageNum = page === 'latest' ? data.length - 1 : page;
       return pageNum < data.length - 1 ? pageNum + 1 : pageNum;
     });
   });

--- a/packages/app/src/components/VisualNode.tsx
+++ b/packages/app/src/components/VisualNode.tsx
@@ -120,6 +120,8 @@ export const VisualNode = memo(
           ? lastRun?.at(processPage === 'latest' ? lastRun.length - 1 : processPage)?.data
           : undefined;
 
+      const isKnownNodeType = useIsKnownNodeType(node.type);
+
       return (
         <div
           className={clsx('node', {
@@ -139,7 +141,13 @@ export const VisualNode = memo(
           data-contextmenutype={`node-${node.type}`}
           onMouseOver={(event) => onMouseOver?.(event, node.id)}
           onMouseOut={(event) => onMouseOut?.(event, node.id)}
-          onDoubleClick={onStartEditing}
+          onDoubleClick={
+            () => {
+              if (isKnownNodeType) {
+                onStartEditing?.();
+              }
+            }
+          }
         >
           {isZoomedOut ? (
             <ZoomedOutVisualNodeContent
@@ -436,7 +444,12 @@ const NormalVisualNodeContent: FC<{
                 <></>
               )}
             </div>
-            <button className="edit-button" onClick={handleEditClick} onMouseDown={handleEditMouseDown} title="Edit">
+            <button className="edit-button" onClick={(e) => {
+              if (isKnownNodeType) {
+                handleEditClick(e);
+              }
+            } 
+          }onMouseDown={handleEditMouseDown} title="Edit">
               <SettingsCogIcon />
             </button>
           </div>


### PR DESCRIPTION
This PR fixes the following bugs:

- Clicking the edit button or double clicking an unknown node from a removed plugin caused the graph to fail to render
https://github.com/Ironclad/rivet/issues/174

- Clicking the forward error of the multi-node output paginator rendered a page with number = data.length, which is 1 more than the actual number of outputs