### PR TITLE
Fix: correctly deserialize image data when remote debugging

### DIFF
--- a/packages/app/src/hooks/useCurrentExecution.ts
+++ b/packages/app/src/hooks/useCurrentExecution.ts
@@ -52,6 +52,28 @@ function sanitizeDataValueForLength(value: DataValue | undefined) {
 
       return value;
     })
+    .with({ type: 'image' }, (value): DataValue => {
+      if (value.value.data instanceof Uint8Array || Array.isArray(value.value.data)) {
+        return value;
+      } else if (Array.isArray(value.value.data)) {
+        return {
+          ...value,
+          value: {
+            ...value.value,
+            data: Uint8Array.from(value.value.data),
+          },
+        };
+      } else {
+        // JSON.stringify converts Uint8Array to an object with numeric keys, so convert it back.
+        return {
+          ...value,
+          value: {
+            ...value.value,
+            data: Uint8Array.from(Object.values(value.value.data)),
+          },
+        };
+      }
+    })
     .otherwise((value): DataValue | undefined => value);
 }
 


### PR DESCRIPTION
See #179 for the full bug explanation.

TL;DR, the remote debugger uses JSON.stringify to send data over the websocket. Uint8Arrays get serialized to objects with numeric keys, which deserialize as... objects with numeric keys. This change detects when that happens, and converts them back into Uint8Arrays.