### PR TITLE
Chore: Typo fixed in external-call.mdx file

### DIFF
--- a/packages/docs/docs/node-reference/external-call.mdx
+++ b/packages/docs/docs/node-reference/external-call.mdx
@@ -35,7 +35,7 @@ External functions are useful for many use-cases, they can do things like:
 
 - Get data from your database
 - Call web APIs
-- Get user informatino about who is running the graph
+- Get user information about who is running the graph
 - Anything else you can think of!
 
 External functions are extremely powerful. They can only be used when running Rivet from a host application, and are not available when running Rivet in the Rivet applicaton. The external function nodes will error when running in the Rivet application. Use [Remote Debugging](../user-guide/remote-debugging.md) to run External Call nodes in the Rivet application.


### PR DESCRIPTION
Typo fixed in packages/docs/docs/node-reference/external-call.mdx file:
informatino -> information
