### PR TITLE
[fix] Refactor duplicate project-opening checks

### DIFF
--- a/packages/app/src/hooks/useLoadProjectWithFileBrowser.ts
+++ b/packages/app/src/hooks/useLoadProjectWithFileBrowser.ts
@@ -22,11 +22,24 @@ export function useLoadProjectWithFileBrowser() {
       await ioProvider.loadProjectData(({ project, testData, path }) => {
         const { data, ...projectData } = project;
 
+        console.log(path, project.metadata.id);
+
         if (
-          Object.values(openedProjects).some((p) => p.fsPath !== path && p.project.metadata.id === project.metadata.id)
+          Object.values(openedProjects).some((p) => p.fsPath === path)
         ) {
           toast.error(
-            `A project with the ID ${project.metadata.id} is already open. Please close that project first to open this one.`,
+            `That project is already open.`,
+          );
+          return;
+        }
+
+        const alreadyOpenedProject = Object.values(openedProjects).find((p) => p.project.metadata.id === project.metadata.id);
+
+        if (
+          alreadyOpenedProject
+        ) {
+          toast.error(
+            `"${alreadyOpenedProject.project.metadata.title} [${alreadyOpenedProject.fsPath.split('/').pop()}]" shares the same ID (${project.metadata.id}) and is already open. Please close that project first to open this one.`,
           );
           return;
         }


### PR DESCRIPTION
Checks whether the user has already opened the project, alerting them specifically of that case. Separately, checks whether two projects have the same project ID, and alerts the user, along with the name and basename of the project, so it's easier to locate that project.

This fixes an issue where you are unable to open any projects past the first one.