### PR TITLE
Removes autocomplete for Mac

### DIFF
--- a/packages/app/src/components/ContextMenu.tsx
+++ b/packages/app/src/components/ContextMenu.tsx
@@ -187,6 +187,8 @@ export const ContextMenu = forwardRef<HTMLDivElement, ContextMenuProps>(
         <div style={floatingStyles} css={menuStyles} ref={refs.setFloating}>
           <div className="context-menu-search">
             <input
+              autoComplete="off"
+              spellCheck={false}
               ref={searchRef}
               autoFocus
               placeholder="Search..."

--- a/packages/app/src/components/GraphList.tsx
+++ b/packages/app/src/components/GraphList.tsx
@@ -524,6 +524,8 @@ export const GraphList: FC<{ onRunGraph?: (graphId: GraphId) => void }> = memo((
     <div css={styles}>
       <div className="search">
         <input
+          autoComplete="off"
+          spellCheck={false}
           type="text"
           placeholder="Search..."
           value={searchText}

--- a/packages/app/src/components/NavigationBar.tsx
+++ b/packages/app/src/components/NavigationBar.tsx
@@ -120,6 +120,8 @@ export const NavigationBar: FC = () => {
             type="text"
             placeholder="Search..."
             autoFocus
+            autoComplete="off"
+            spellCheck={false}
             value={searching.query}
             onChange={(e) => setSearching({ searching: true, query: e.target.value })}
             onKeyDown={(e) => {

--- a/packages/app/src/components/PluginsOverlay.tsx
+++ b/packages/app/src/components/PluginsOverlay.tsx
@@ -316,6 +316,8 @@ export const PluginsOverlay: FC = () => {
         <h1>Plugin</h1>
         <div className="plugin-search">
           <TextField
+            autoComplete="off"
+            spellCheck={false}
             placeholder="Search..."
             value={searchText}
             onChange={(e) => setSearchText((e.target as HTMLInputElement).value)}

--- a/packages/app/src/components/editors/StringEditor.tsx
+++ b/packages/app/src/components/editors/StringEditor.tsx
@@ -71,6 +71,8 @@ export const StringEditor: FC<{
             value={value}
             isReadOnly={isReadonly}
             autoFocus={autoFocus}
+            autoComplete="off"
+            spellCheck={false}
             placeholder={placeholder}
             maxLength={maxLength}
             onChange={(e) => onChange((e.target as HTMLInputElement).value)}


### PR DESCRIPTION
Removes Mac autocomplete stuff from several fields.

This has caused me a lot of sadness. Here are some examples of why:

When adding a new node, sometimes the autocomplete gets in the way of using the search input. In the screenshot below, let's say I wanted "Trim Chat Messages," and typed in "Chat." Now, when I press the "down" button, it selects my autocomplete 😬
![Screenshot 2023-11-14 at 8 07 50 AM](https://github.com/Ironclad/rivet/assets/448108/0e98a185-899a-4552-89a9-1daa4b2e1782)

Another sad example is setting variable names. If I type in "calculate" with a lowercase "C," it auto-capitalizes the "C" if I click away from the input.
![Screenshot 2023-11-14 at 8 04 28 AM](https://github.com/Ironclad/rivet/assets/448108/ad9080ac-4c82-43d9-84a6-011c3ee1639b)
![Screenshot 2023-11-14 at 8 04 33 AM](https://github.com/Ironclad/rivet/assets/448108/16fde662-5c9e-415a-9325-e037002cd72c)
