### PR TITLE
[Fix] Token Counts - fix request token estimate and add GPT Functions to estimate

### DIFF
--- a/packages/core/src/integrations/GptTokenizerTokenizer.ts
+++ b/packages/core/src/integrations/GptTokenizerTokenizer.ts
@@ -56,7 +56,7 @@ export class GptTokenizerTokenizer implements Tokenizer {
    * @param functions
    */
   private convertGptFunctionsToPromptString(functions: GptFunction[]): string {
-    const encoded = `
+    return `
 # Tools
 
 ## functions
@@ -73,7 +73,5 @@ ${Object.entries((fn.parameters as any)?.properties ?? {})
 }
 } // namespace functions
 `;
-    console.log(encoded);
-    return encoded;
   }
 }

--- a/packages/core/src/integrations/Tokenizer.ts
+++ b/packages/core/src/integrations/Tokenizer.ts
@@ -1,4 +1,4 @@
-import type { ChartNode, ChatMessage } from '../index.js';
+import type { ChartNode, ChatMessage, GptFunction } from '../index.js';
 
 export type TokenizerCallInfo = {
   node: ChartNode;
@@ -11,5 +11,5 @@ export type Tokenizer = {
 
   getTokenCountForString(input: string, info: TokenizerCallInfo): number;
 
-  getTokenCountForMessages(messages: ChatMessage[], info: TokenizerCallInfo): Promise<number>;
+  getTokenCountForMessages(messages: ChatMessage[], gptFunctions: GptFunction[] | undefined, info: TokenizerCallInfo): Promise<number>;
 };

--- a/packages/core/src/model/nodes/AssemblePromptNode.ts
+++ b/packages/core/src/model/nodes/AssemblePromptNode.ts
@@ -157,7 +157,7 @@ export class AssemblePromptNodeImpl extends NodeImpl<AssemblePromptNode> {
     };
 
     if (this.data.computeTokenCount) {
-      const tokenCount = await context.tokenizer.getTokenCountForMessages(outMessages, {
+      const tokenCount = await context.tokenizer.getTokenCountForMessages(outMessages, undefined, {
         node: this.chartNode,
       });
       output['tokenCount' as PortId] = {

--- a/packages/core/src/model/nodes/ChatNode.ts
+++ b/packages/core/src/model/nodes/ChatNode.ts
@@ -756,7 +756,7 @@ export class ChatNodeImpl extends NodeImpl<ChatNode> {
       model: finalModel,
       endpoint: resolvedEndpointAndHeaders.endpoint,
     };
-    const tokenCount = await context.tokenizer.getTokenCountForMessages(messages, tokenizerInfo);
+    const tokenCount = await context.tokenizer.getTokenCountForMessages(messages, functions, tokenizerInfo);
 
     if (tokenCount >= openaiModel.maxTokens) {
       throw new Error(

--- a/packages/core/src/model/nodes/ChatNode.ts
+++ b/packages/core/src/model/nodes/ChatNode.ts
@@ -938,7 +938,7 @@ export class ChatNodeImpl extends NodeImpl<ChatNode> {
           }
 
           output['in-messages' as PortId] = { type: 'chat-message[]', value: messages };
-          output['requestTokens' as PortId] = { type: 'number', value: tokenCount * numberOfChoices };
+          output['requestTokens' as PortId] = { type: 'number', value: tokenCount * (numberOfChoices ?? 1) };
 
           const responseTokenCount = responseChoicesParts
             .map((choiceParts) => context.tokenizer.getTokenCountForString(choiceParts.join(), tokenizerInfo))

--- a/packages/core/src/model/nodes/PromptNode.ts
+++ b/packages/core/src/model/nodes/PromptNode.ts
@@ -268,7 +268,7 @@ export class PromptNodeImpl extends NodeImpl<PromptNode> {
     };
 
     if (this.chartNode.data.computeTokenCount) {
-      const tokenCount = await context.tokenizer.getTokenCountForMessages([message], {
+      const tokenCount = await context.tokenizer.getTokenCountForMessages([message], undefined, {
         node: this.chartNode,
       });
       outputs['tokenCount' as PortId] = {

--- a/packages/core/src/model/nodes/TrimChatMessagesNode.ts
+++ b/packages/core/src/model/nodes/TrimChatMessagesNode.ts
@@ -139,7 +139,7 @@ export class TrimChatMessagesNodeImpl extends NodeImpl<TrimChatMessagesNode> {
       node: this.chartNode,
     };
 
-    let tokenCount = await context.tokenizer.getTokenCountForMessages(trimmedMessages, tokenizerInfo);
+    let tokenCount = await context.tokenizer.getTokenCountForMessages(trimmedMessages, undefined, tokenizerInfo);
 
     while (tokenCount > maxTokenCount) {
       if (removeFromBeginning) {
@@ -147,7 +147,7 @@ export class TrimChatMessagesNodeImpl extends NodeImpl<TrimChatMessagesNode> {
       } else {
         trimmedMessages.pop();
       }
-      tokenCount = await context.tokenizer.getTokenCountForMessages(trimmedMessages, tokenizerInfo);
+      tokenCount = await context.tokenizer.getTokenCountForMessages(trimmedMessages, undefined, tokenizerInfo);
     }
 
     return {


### PR DESCRIPTION
Per #171, token estimates are incorrect for OpenAI Chat Node. This is caused by at least two different issues, both of which are addressed in this PR:
1. Request Tokens were dependent on `numberOfChoices` being set. This parameter defaults to 1, and is often unused, so this was resulting in `requestTokens` coming out as `NaN`.
2. GPT Functions add to the request tokens in an unclear way. This adds a janky method for estimating how many tokens, based on this forum thread: https://community.openai.com/t/how-to-calculate-the-tokens-when-using-function-call/266573/24

## GPT Functions

These are included in the context of the request in an opaque way. The forum thread suggests that the function definitions are converted into a TypeScript-like syntax, which is then tokenized, and that this syntax looks something like:

```
# Tools

## functions

namespace functions {

// Description of example function the AI will repeat back to the user
type function_name = (_: {
// description of function property 1: string
property1?: string,
// description of function property 2: string w enum
property2?: "enum_yes" | "enum_no",
}) => any;

} // namespace functions
```

To estimate request tokens, we convert the list of GPT Functions into this format, and then tokenize it.

I did a very simplistic test of this, by first calling OpenAI via Rivet, and then directly calling the OpenAI API with one function call, two function calls, and a few messages. The token estimates were off by 1, 4, and 4 tokens. There's almost certainly room for improvement here (there's another library we may want to consider: https://github.com/hmarr/openai-chat-tokens), but I think this is a good start.