### PR TITLE
[Fix] GPT-4 Vision supports node executor (and Node.js execution in general)

### DIFF
--- a/packages/core/src/utils/base64.ts
+++ b/packages/core/src/utils/base64.ts
@@ -1,11 +1,17 @@
 export async function uint8ArrayToBase64(uint8Array: Uint8Array) {
-  const blob = new Blob([uint8Array], { type: 'application/octet-stream' });
-  const dataUrl = await new Promise<string>((resolve) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.readAsDataURL(blob);
-  });
-  return dataUrl.split(',')[1];
+  if (typeof window === 'undefined') {
+    // Node executor
+    return Buffer.from(uint8Array).toString('base64');
+  } else {
+    // Browser executor
+    const blob = new Blob([uint8Array], { type: 'application/octet-stream' });
+    const dataUrl = await new Promise<string>((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.readAsDataURL(blob);
+    });
+    return dataUrl.split(',')[1];
+  }
 }
 
 export function base64ToUint8Array(base64: string) {


### PR DESCRIPTION
Image to base64 conversion relied on FileReader, which does not exist in Node.js. So, use Buffer when running in Node.js instead.