### PR TITLE
Fixes the JavaScript example in CodeNode

### DIFF
--- a/packages/core/src/model/nodes/CodeNode.ts
+++ b/packages/core/src/model/nodes/CodeNode.ts
@@ -39,8 +39,8 @@ export class CodeNodeImpl extends NodeImpl<CodeNode> {
           // Output values must by typed as well (e.g. { bar: { type: 'string', value: 'bar' } }
           return {
             output1: {
-              type: inputs.input1.type;
-              value: inputs.input1.value;
+              type: inputs.input1.type,
+              value: inputs.input1.value
             }
           };
         `,


### PR DESCRIPTION
The coding example in the `CodeNode` has syntax errors and this PR fixes that example.