### PR TITLE
fix: hotkeys on Windows by adding a custom hook

### DIFF
--- a/packages/app/src/components/RivetApp.tsx
+++ b/packages/app/src/components/RivetApp.tsx
@@ -1,4 +1,4 @@
-import { useWindowsHotfix } from '../hooks/useWindowsHotfix';
+import { useWindowsHotkeysFix } from '../hooks/useWindowsHotkeysFix';
 import { GraphBuilder } from './GraphBuilder.js';
 import { OverlayTabs } from './OverlayTabs.js';
 import { type FC, useEffect } from 'react';
@@ -50,7 +50,7 @@ export const RivetApp: FC = () => {
     onRunGraph: tryRunGraph,
   });
 
-  useWindowsHotfix();
+  useWindowsHotkeysFix();
 
   const checkForUpdate = useCheckForUpdate();
 

--- a/packages/app/src/components/RivetApp.tsx
+++ b/packages/app/src/components/RivetApp.tsx
@@ -1,3 +1,4 @@
+import { useWindowsHotfix } from '../hooks/useWindowsHotfix';
 import { GraphBuilder } from './GraphBuilder.js';
 import { OverlayTabs } from './OverlayTabs.js';
 import { type FC, useEffect } from 'react';
@@ -48,6 +49,8 @@ export const RivetApp: FC = () => {
   useMenuCommands({
     onRunGraph: tryRunGraph,
   });
+
+  useWindowsHotfix();
 
   const checkForUpdate = useCheckForUpdate();
 

--- a/packages/app/src/hooks/useMenuCommands.ts
+++ b/packages/app/src/hooks/useMenuCommands.ts
@@ -14,7 +14,7 @@ import { useToggleRemoteDebugger } from '../components/DebuggerConnectPanel';
 import { lastRunDataByNodeState } from '../state/dataFlow';
 import { useImportGraph } from './useImportGraph';
 
-type MenuIds =
+export type MenuIds =
   | 'settings'
   | 'quit'
   | 'new_project'

--- a/packages/app/src/hooks/useWindowsHotfix.tsx
+++ b/packages/app/src/hooks/useWindowsHotfix.tsx
@@ -2,55 +2,55 @@ import { useEffect } from 'react';
 import { type MenuIds, useRunMenuCommand } from './useMenuCommands';
 
 interface HotfixWindow extends Window {
-    __tauri_hotfix?: boolean;
+  __tauri_hotfix?: boolean;
 }
 declare let window: HotfixWindow;
 
 const isWindowsPlatform = typeof navigator !== 'undefined' && navigator.userAgent.includes('Win64');
 
 if (isWindowsPlatform) {
-    console.warn('Hotfix applied for Windows platform');
+  console.warn('Hotfix applied for Windows platform');
 }
 
 /**
  * Applies a keyboard shortcut hotfix for Windows platform.
  */
 export const useWindowsHotfix = () => {
-    const runMenuCommandImpl = useRunMenuCommand();
+  const runMenuCommandImpl = useRunMenuCommand();
 
-    // @see https://github.com/Ironclad/rivet/issues/261
-    useEffect(() => {
-        if (typeof window === 'undefined' || !isWindowsPlatform || window.__tauri_hotfix) {
-            return;
-        }
+  // @see https://github.com/Ironclad/rivet/issues/261
+  useEffect(() => {
+    if (typeof window === 'undefined' || !isWindowsPlatform || window.__tauri_hotfix) {
+      return;
+    }
 
-        const onKeyUp = ({ key, ctrlKey, shiftKey }: KeyboardEvent) => {
-            const code = `${ctrlKey ? 'CmdOrCtrl+' : ''}${shiftKey ? 'Shift+' : ''}${key.toUpperCase()}`;
-            const codeToMenuId: Record<string, MenuIds> = {
-                F5: 'remote_debugger',
-                'CmdOrCtrl+Shift+O': 'load_recording',
-                'CmdOrCtrl+N': 'new_project',
-                'CmdOrCtrl+O': 'open_project',
-                'CmdOrCtrl+S': 'save_project',
-                'CmdOrCtrl+Shift+E': 'export_graph',
-                'CmdOrCtrl+Shift+I': 'import_graph',
-                'CmdOrCtrl+Shift+S': 'save_project_as',
-                'CmdOrCtrl+ENTER': 'run',
-            };
-            if (codeToMenuId[code]) {
-                console.warn(`Hotfix: ${code} -> ${codeToMenuId[code]}`);
-                runMenuCommandImpl(codeToMenuId[code]!);
-            }
-        };
+    const onKeyUp = ({ key, ctrlKey, shiftKey }: KeyboardEvent) => {
+      const code = `${ctrlKey ? 'CmdOrCtrl+' : ''}${shiftKey ? 'Shift+' : ''}${key.toUpperCase()}`;
+      const codeToMenuId: Record<string, MenuIds> = {
+        F5: 'remote_debugger',
+        'CmdOrCtrl+Shift+O': 'load_recording',
+        'CmdOrCtrl+N': 'new_project',
+        'CmdOrCtrl+O': 'open_project',
+        'CmdOrCtrl+S': 'save_project',
+        'CmdOrCtrl+Shift+E': 'export_graph',
+        'CmdOrCtrl+Shift+I': 'import_graph',
+        'CmdOrCtrl+Shift+S': 'save_project_as',
+        'CmdOrCtrl+ENTER': 'run',
+      };
+      if (codeToMenuId[code]) {
+        console.warn(`Hotfix: ${code} -> ${codeToMenuId[code]}`);
+        runMenuCommandImpl(codeToMenuId[code]!);
+      }
+    };
 
-        window.__tauri_hotfix = true; // protects against double usage of hook by mistake
-        window.addEventListener('keyup', onKeyUp);
+    window.__tauri_hotfix = true; // protects against double usage of hook by mistake
+    window.addEventListener('keyup', onKeyUp);
 
-        return () => {
-            window.removeEventListener('keyup', onKeyUp);
-            window.__tauri_hotfix = false;
-        };
-    }, [runMenuCommandImpl]);
+    return () => {
+      window.removeEventListener('keyup', onKeyUp);
+      window.__tauri_hotfix = false;
+    };
+  }, [runMenuCommandImpl]);
 
-    return isWindowsPlatform;
+  return isWindowsPlatform;
 };

--- a/packages/app/src/hooks/useWindowsHotfix.tsx
+++ b/packages/app/src/hooks/useWindowsHotfix.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { type MenuIds, useRunMenuCommand } from './useMenuCommands';
+
+interface HotfixWindow extends Window {
+    __tauri_hotfix?: boolean;
+}
+declare let window: HotfixWindow;
+
+const isWindowsPlatform = typeof navigator !== 'undefined' && navigator.userAgent.includes('Win64');
+
+if(isWindowsPlatform) {
+    console.warn('Hotfix applied for Windows platform');
+}
+
+/**
+ * Applies a keyboard shortcut hotfix for Windows platform.
+ */
+export const useWindowsHotfix = () => {
+    const runMenuCommandImpl = useRunMenuCommand();
+
+    // @see https://github.com/Ironclad/rivet/issues/261
+    useEffect(() => {
+        if (typeof window === 'undefined' || !isWindowsPlatform || window.__tauri_hotfix) {
+            return;
+        }
+
+        const onKeyUp = ({ key, ctrlKey, shiftKey }: KeyboardEvent) => {
+            const code = `${ctrlKey ? 'CmdOrCtrl+' : ''}${shiftKey ? 'Shift+' : ''}${key.toUpperCase()}`;
+            const codeToMenuId: Record<string, MenuIds> = {
+                F5: 'remote_debugger',
+                'CmdOrCtrl+Shift+O': 'load_recording',
+                'CmdOrCtrl+N': 'new_project',
+                'CmdOrCtrl+O': 'open_project',
+                'CmdOrCtrl+S': 'save_project',
+                'CmdOrCtrl+Shift+E': 'export_graph',
+                'CmdOrCtrl+Shift+I': 'import_graph',
+                'CmdOrCtrl+Shift+S': 'save_project_as',
+                'CmdOrCtrl+ENTER': 'run',
+            };
+            if (codeToMenuId[code]) {
+                console.warn(`Hotfix: ${code} -> ${codeToMenuId[code]}`);
+                runMenuCommandImpl(codeToMenuId[code]!);
+            }
+        };
+
+        window.__tauri_hotfix = true; // protects against double usage of hook by mistake
+        window.addEventListener('keyup', onKeyUp);
+
+        return () => {
+            window.removeEventListener('keyup', onKeyUp);
+            window.__tauri_hotfix = false;
+        };
+    }, [runMenuCommandImpl]);
+
+    return isWindowsPlatform;
+};

--- a/packages/app/src/hooks/useWindowsHotfix.tsx
+++ b/packages/app/src/hooks/useWindowsHotfix.tsx
@@ -8,7 +8,7 @@ declare let window: HotfixWindow;
 
 const isWindowsPlatform = typeof navigator !== 'undefined' && navigator.userAgent.includes('Win64');
 
-if(isWindowsPlatform) {
+if (isWindowsPlatform) {
     console.warn('Hotfix applied for Windows platform');
 }
 

--- a/packages/app/src/hooks/useWindowsHotkeysFix.tsx
+++ b/packages/app/src/hooks/useWindowsHotkeysFix.tsx
@@ -1,26 +1,26 @@
 import { useEffect } from 'react';
 import { type MenuIds, useRunMenuCommand } from './useMenuCommands';
 
-interface HotfixWindow extends Window {
-  __tauri_hotfix?: boolean;
+interface HotkeyFixWindow extends Window {
+  __tauri_hotkey?: boolean;
 }
-declare let window: HotfixWindow;
+declare let window: HotkeyFixWindow;
 
 const isWindowsPlatform = typeof navigator !== 'undefined' && navigator.userAgent.includes('Win64');
 
 if (isWindowsPlatform) {
-  console.warn('Hotfix applied for Windows platform');
+  console.warn('Fix applied for Windows platform');
 }
 
 /**
- * Applies a keyboard shortcut hotfix for Windows platform.
+ * Applies a keyboard shortcut fix for Windows platform.
  */
-export const useWindowsHotfix = () => {
+export const useWindowsHotkeysFix = () => {
   const runMenuCommandImpl = useRunMenuCommand();
 
   // @see https://github.com/Ironclad/rivet/issues/261
   useEffect(() => {
-    if (typeof window === 'undefined' || !isWindowsPlatform || window.__tauri_hotfix) {
+    if (typeof window === 'undefined' || !isWindowsPlatform || window.__tauri_hotkey) {
       return;
     }
 
@@ -38,17 +38,17 @@ export const useWindowsHotfix = () => {
         'CmdOrCtrl+ENTER': 'run',
       };
       if (codeToMenuId[code]) {
-        console.warn(`Hotfix: ${code} -> ${codeToMenuId[code]}`);
+        console.warn(`Hotkey Fix: ${code} -> ${codeToMenuId[code]}`);
         runMenuCommandImpl(codeToMenuId[code]!);
       }
     };
 
-    window.__tauri_hotfix = true; // protects against double usage of hook by mistake
+    window.__tauri_hotkey = true; // protects against double usage of hook by mistake
     window.addEventListener('keyup', onKeyUp);
 
     return () => {
       window.removeEventListener('keyup', onKeyUp);
-      window.__tauri_hotfix = false;
+      window.__tauri_hotkey = false;
     };
   }, [runMenuCommandImpl]);
 


### PR DESCRIPTION
Adds a hook that applies an onKeyUp listener to `window` and triggers menu actions.

Only applies the hook when the userAgent is `Win64`.

Resolves #261 