### PR TITLE
fix: input/output names on CodeNode can crash render

### DIFF
--- a/packages/core/src/model/nodes/CodeNode.ts
+++ b/packages/core/src/model/nodes/CodeNode.ts
@@ -15,6 +15,9 @@ import { nodeDefinition } from '../NodeDefinition.js';
 
 export type CodeNode = ChartNode<'code', CodeNodeData>;
 
+const maskInput = (name: string) => name.trim().replace(/[^a-zA-Z0-9_]/g, '_');
+const asValidNames = (names: string[]): string[] => Array(...new Set(names.map(maskInput))).filter(Boolean);
+
 export type CodeNodeData = {
   code: string;
   inputNames: string | string[];
@@ -59,7 +62,7 @@ export class CodeNodeImpl extends NodeImpl<CodeNode> {
         : [this.data.inputNames]
       : [];
 
-    return inputNames.map((inputName) => {
+    return asValidNames(inputNames).map((inputName) => {
       return {
         type: 'any',
         id: inputName.trim() as PortId,
@@ -77,7 +80,7 @@ export class CodeNodeImpl extends NodeImpl<CodeNode> {
         : [this.data.outputNames]
       : [];
 
-    return outputNames.map((outputName) => {
+    return asValidNames(outputNames).map((outputName) => {
       return {
         id: outputName.trim() as PortId,
         title: outputName.trim(),


### PR DESCRIPTION
Fixes #263 by ensuring the input/output names used by `CodeNode` are valid.

- rewrite non-alphanumeric letters as "_" underscore
- removes duplicate inputs/outputs which caused errors
- removes empty inputs/outputs from list

> Note, item 1 could be a breaking change for anyone using input names like "bad$xamp!es" as it gets rewritten to "bad_xamp_es". I made this change without discussing, but can be reverted if needed.