### PR TITLE
fix: adds a temp cache of node heights to fix node flickering

### DIFF
--- a/packages/app/src/components/DraggableNode.tsx
+++ b/packages/app/src/components/DraggableNode.tsx
@@ -8,7 +8,7 @@ import {
   type NodeOutputDefinition,
 } from '@ironclad/rivet-core';
 import { type MouseEvent, type FC } from 'react';
-import type { NodeHeightCache } from '../hooks/useNodeBodyHeight';
+import type { HeightCache } from '../hooks/useNodeBodyHeight';
 import { VisualNode } from './VisualNode.js';
 import { useStableCallback } from '../hooks/useStableCallback.js';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -16,7 +16,7 @@ import { type ProcessDataForNode } from '../state/dataFlow';
 import { type DraggingWireDef } from '../state/graphBuilder';
 
 interface DraggableNodeProps {
-  cache: NodeHeightCache;
+  heightCache: HeightCache;
   node: ChartNode;
   connections?: NodeConnection[];
   isSelected?: boolean;
@@ -56,7 +56,7 @@ interface DraggableNodeProps {
 }
 
 export const DraggableNode: FC<DraggableNodeProps> = ({
-  cache,
+  heightCache,
   node,
   connections = [],
   isSelected = false,
@@ -84,7 +84,7 @@ export const DraggableNode: FC<DraggableNodeProps> = ({
       <VisualNode
         ref={setNodeRef}
         isSelected={isSelected}
-        cache={cache}
+        heightCache={heightCache}
         node={node}
         connections={connections}
         isDragging={isDragging}

--- a/packages/app/src/components/DraggableNode.tsx
+++ b/packages/app/src/components/DraggableNode.tsx
@@ -8,6 +8,7 @@ import {
   type NodeOutputDefinition,
 } from '@ironclad/rivet-core';
 import { type MouseEvent, type FC } from 'react';
+import type { NodeHeightCache } from '../hooks/useNodeBodyHeight';
 import { VisualNode } from './VisualNode.js';
 import { useStableCallback } from '../hooks/useStableCallback.js';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -15,6 +16,7 @@ import { type ProcessDataForNode } from '../state/dataFlow';
 import { type DraggingWireDef } from '../state/graphBuilder';
 
 interface DraggableNodeProps {
+  cache: NodeHeightCache;
   node: ChartNode;
   connections?: NodeConnection[];
   isSelected?: boolean;
@@ -54,6 +56,7 @@ interface DraggableNodeProps {
 }
 
 export const DraggableNode: FC<DraggableNodeProps> = ({
+  cache,
   node,
   connections = [],
   isSelected = false,
@@ -81,6 +84,7 @@ export const DraggableNode: FC<DraggableNodeProps> = ({
       <VisualNode
         ref={setNodeRef}
         isSelected={isSelected}
+        cache={cache}
         node={node}
         connections={connections}
         isDragging={isDragging}

--- a/packages/app/src/components/NodeBody.tsx
+++ b/packages/app/src/components/NodeBody.tsx
@@ -1,5 +1,5 @@
 import { type FC, Suspense, memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { type NodeHeightCache, useNodeBodyHeight } from '../hooks/useNodeBodyHeight';
+import { type HeightCache, useNodeBodyHeight } from '../hooks/useNodeBodyHeight';
 import { useUnknownNodeComponentDescriptorFor } from '../hooks/useNodeTypes.js';
 import {
   type ChartNode,
@@ -20,11 +20,11 @@ import { useGetRivetUIContext } from '../hooks/useGetRivetUIContext';
 import { useAsyncEffect } from 'use-async-effect';
 import { toast } from 'react-toastify';
 
-export const NodeBody: FC<{ cache: NodeHeightCache, node: ChartNode }> = memo(({ cache, node }) => {
+export const NodeBody: FC<{ heightCache: HeightCache, node: ChartNode }> = memo(({ heightCache, node }) => {
   const { Body } = useUnknownNodeComponentDescriptorFor(node);
   useDependsOnPlugins();
 
-  const body = Body ? <Body node={node} /> : <UnknownNodeBody cache={cache} node={node} />;
+  const body = Body ? <Body node={node} /> : <UnknownNodeBody heightCache={heightCache} node={node} />;
 
   return <div className="node-body">{body}</div>;
 });
@@ -40,11 +40,11 @@ const UnknownNodeBodyWrapper = styled.div<{
   font-family: ${(props) => (props.fontFamily === 'monospace' ? "'Roboto Mono', monospace" : "'Roboto', sans-serif")};
 `;
 
-const UnknownNodeBody: FC<{ cache: NodeHeightCache, node: ChartNode }> = ({ cache, node }) => {
+const UnknownNodeBody: FC<{ heightCache: HeightCache, node: ChartNode }> = ({ heightCache, node }) => {
   const getUIContext = useGetRivetUIContext();
 
   const [body, setBody] = useState<RenderedNodeBody | undefined>();
-  const { ref, height } = useNodeBodyHeight(cache, node.id, !!body);
+  const { ref, height } = useNodeBodyHeight(heightCache, node.id, !!body);
 
   useAsyncEffect(async () => {
     try {

--- a/packages/app/src/components/NodeBody.tsx
+++ b/packages/app/src/components/NodeBody.tsx
@@ -1,4 +1,5 @@
 import { type FC, Suspense, memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { type NodeHeightCache, useNodeBodyHeight } from '../hooks/useNodeBodyHeight';
 import { useUnknownNodeComponentDescriptorFor } from '../hooks/useNodeTypes.js';
 import {
   type ChartNode,
@@ -19,11 +20,11 @@ import { useGetRivetUIContext } from '../hooks/useGetRivetUIContext';
 import { useAsyncEffect } from 'use-async-effect';
 import { toast } from 'react-toastify';
 
-export const NodeBody: FC<{ node: ChartNode }> = memo(({ node }) => {
+export const NodeBody: FC<{ cache: NodeHeightCache, node: ChartNode }> = memo(({ cache, node }) => {
   const { Body } = useUnknownNodeComponentDescriptorFor(node);
   useDependsOnPlugins();
 
-  const body = Body ? <Body node={node} /> : <UnknownNodeBody node={node} />;
+  const body = Body ? <Body node={node} /> : <UnknownNodeBody cache={cache} node={node} />;
 
   return <div className="node-body">{body}</div>;
 });
@@ -39,10 +40,11 @@ const UnknownNodeBodyWrapper = styled.div<{
   font-family: ${(props) => (props.fontFamily === 'monospace' ? "'Roboto Mono', monospace" : "'Roboto', sans-serif")};
 `;
 
-const UnknownNodeBody: FC<{ node: ChartNode }> = ({ node }) => {
+const UnknownNodeBody: FC<{ cache: NodeHeightCache, node: ChartNode }> = ({ cache, node }) => {
   const getUIContext = useGetRivetUIContext();
 
   const [body, setBody] = useState<RenderedNodeBody | undefined>();
+  const { ref, height } = useNodeBodyHeight(cache, node.id, !!body);
 
   useAsyncEffect(async () => {
     try {
@@ -78,7 +80,7 @@ const UnknownNodeBody: FC<{ node: ChartNode }> = ({ node }) => {
   }));
 
   return (
-    <div>
+    <div ref={ref} style={{ height }}>
       {renderedSpecs.map(({ spec, rendered }, i) => (
         <UnknownNodeBodyWrapper key={i} fontFamily={spec.fontFamily ?? 'sans-serif'} fontSize={spec.fontSize ?? 12}>
           {rendered}

--- a/packages/app/src/components/NodeCanvas.tsx
+++ b/packages/app/src/components/NodeCanvas.tsx
@@ -1,4 +1,5 @@
 import { DndContext, DragOverlay, useDroppable } from '@dnd-kit/core';
+import { useNodeHeightCache } from '../hooks/useNodeBodyHeight';
 import { DraggableNode } from './DraggableNode.js';
 import { css } from '@emotion/react';
 import { nodeStyles } from './nodeStyles.js';
@@ -196,6 +197,8 @@ export const NodeCanvas: FC<NodeCanvasProps> = ({
   const { draggingNodes, onNodeStartDrag, onNodeDragged } = useDraggingNode(onNodesChanged);
   const { draggingWire, onWireStartDrag, onWireEndDrag } = useDraggingWire(onConnectionsChanged);
   useWireDragScrolling();
+
+  const cache = useNodeHeightCache();
 
   const {
     contextMenuRef,
@@ -621,6 +624,7 @@ export const NodeCanvas: FC<NodeCanvasProps> = ({
               return (
                 <DraggableNode
                   key={node.id}
+                  cache={cache}
                   node={node}
                   connections={nodeConnections}
                   isSelected={highlightedNodes.includes(node.id) || searchMatchingNodes.includes(node.id)}
@@ -665,6 +669,7 @@ export const NodeCanvas: FC<NodeCanvasProps> = ({
             {draggingNodes.map((node) => (
               <VisualNode
                 key={node.id}
+                cache={cache}
                 node={node}
                 connections={draggingNodeConnections}
                 isOverlay

--- a/packages/app/src/components/NodeCanvas.tsx
+++ b/packages/app/src/components/NodeCanvas.tsx
@@ -624,7 +624,7 @@ export const NodeCanvas: FC<NodeCanvasProps> = ({
               return (
                 <DraggableNode
                   key={node.id}
-                  cache={cache}
+                  heightCache={cache}
                   node={node}
                   connections={nodeConnections}
                   isSelected={highlightedNodes.includes(node.id) || searchMatchingNodes.includes(node.id)}
@@ -669,7 +669,7 @@ export const NodeCanvas: FC<NodeCanvasProps> = ({
             {draggingNodes.map((node) => (
               <VisualNode
                 key={node.id}
-                cache={cache}
+                heightCache={cache}
                 node={node}
                 connections={draggingNodeConnections}
                 isOverlay

--- a/packages/app/src/components/VisualNode.tsx
+++ b/packages/app/src/components/VisualNode.tsx
@@ -21,6 +21,7 @@ import {
   type PortId,
   type NodeOutputDefinition,
 } from '@ironclad/rivet-core';
+import type { NodeHeightCache } from '../hooks/useNodeBodyHeight';
 import { type ProcessDataForNode, lastRunData, selectedProcessPage } from '../state/dataFlow.js';
 import { NodeBody } from './NodeBody.js';
 import { NodeOutput } from './NodeOutput.js';
@@ -46,6 +47,7 @@ import {
 import { Tooltip } from './Tooltip';
 
 export type VisualNodeProps = {
+  cache: NodeHeightCache;
   node: ChartNode;
   connections?: NodeConnection[];
   xDelta?: number;
@@ -95,6 +97,7 @@ export const VisualNode = memo(
   forwardRef<HTMLDivElement, VisualNodeProps>(
     (
       {
+        cache,
         node,
         connections = [],
         handleAttributes,
@@ -222,6 +225,7 @@ export const VisualNode = memo(
             />
           ) : (
             <NormalVisualNodeContent
+              cache={cache}
               node={node}
               connections={connections}
               onWireStartDrag={onWireStartDrag}
@@ -377,6 +381,7 @@ const ZoomedOutVisualNodeContent: FC<{
 ZoomedOutVisualNodeContent.displayName = 'ZoomedOutVisualNodeContent';
 
 const NormalVisualNodeContent: FC<{
+  cache: NodeHeightCache;
   node: ChartNode;
   connections?: NodeConnection[];
   handleAttributes?: HTMLAttributes<HTMLDivElement>;
@@ -410,6 +415,7 @@ const NormalVisualNodeContent: FC<{
   ) => void;
 }> = memo(
   ({
+    cache,
     node,
     connections = [],
     lastRun,
@@ -604,7 +610,7 @@ const NormalVisualNodeContent: FC<{
         </div>
         <ErrorBoundary fallback={<div>Error rendering node body</div>}>
           {isKnownNodeType ? (
-            <NodeBody node={node} />
+            <NodeBody cache={cache} node={node} />
           ) : (
             <div>Unknown node type {node.type} - are you missing a plugin?</div>
           )}

--- a/packages/app/src/components/VisualNode.tsx
+++ b/packages/app/src/components/VisualNode.tsx
@@ -21,7 +21,7 @@ import {
   type PortId,
   type NodeOutputDefinition,
 } from '@ironclad/rivet-core';
-import type { NodeHeightCache } from '../hooks/useNodeBodyHeight';
+import type { HeightCache } from '../hooks/useNodeBodyHeight';
 import { type ProcessDataForNode, lastRunData, selectedProcessPage } from '../state/dataFlow.js';
 import { NodeBody } from './NodeBody.js';
 import { NodeOutput } from './NodeOutput.js';
@@ -47,7 +47,7 @@ import {
 import { Tooltip } from './Tooltip';
 
 export type VisualNodeProps = {
-  cache: NodeHeightCache;
+  heightCache: HeightCache;
   node: ChartNode;
   connections?: NodeConnection[];
   xDelta?: number;
@@ -97,7 +97,7 @@ export const VisualNode = memo(
   forwardRef<HTMLDivElement, VisualNodeProps>(
     (
       {
-        cache,
+        heightCache,
         node,
         connections = [],
         handleAttributes,
@@ -225,7 +225,7 @@ export const VisualNode = memo(
             />
           ) : (
             <NormalVisualNodeContent
-              cache={cache}
+              heightCache={heightCache}
               node={node}
               connections={connections}
               onWireStartDrag={onWireStartDrag}
@@ -381,7 +381,7 @@ const ZoomedOutVisualNodeContent: FC<{
 ZoomedOutVisualNodeContent.displayName = 'ZoomedOutVisualNodeContent';
 
 const NormalVisualNodeContent: FC<{
-  cache: NodeHeightCache;
+  heightCache: HeightCache;
   node: ChartNode;
   connections?: NodeConnection[];
   handleAttributes?: HTMLAttributes<HTMLDivElement>;
@@ -415,7 +415,7 @@ const NormalVisualNodeContent: FC<{
   ) => void;
 }> = memo(
   ({
-    cache,
+    heightCache,
     node,
     connections = [],
     lastRun,
@@ -610,7 +610,7 @@ const NormalVisualNodeContent: FC<{
         </div>
         <ErrorBoundary fallback={<div>Error rendering node body</div>}>
           {isKnownNodeType ? (
-            <NodeBody cache={cache} node={node} />
+            <NodeBody heightCache={heightCache} node={node} />
           ) : (
             <div>Unknown node type {node.type} - are you missing a plugin?</div>
           )}

--- a/packages/app/src/hooks/useNodeBodyHeight.tsx
+++ b/packages/app/src/hooks/useNodeBodyHeight.tsx
@@ -1,0 +1,59 @@
+import { type NodeId } from '@ironclad/rivet-core';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useRecoilValue } from 'recoil';
+import { nodesState } from '../state/graph';
+
+export interface NodeHeightCache {
+  get: (nodeId: NodeId) => number | undefined;
+
+  has: (nodeId: NodeId) => boolean;
+
+  set: (nodeId: NodeId, height: number | undefined) => void;
+}
+
+/**
+ * A cache of node heights. This is used when a node is unmounted and moved to the dragging list, since the node's
+ * body needs to be re-rendered in order to get its height. This cache allows us to avoid flickering when the node
+ * is first rendered in the dragging list.
+ */
+export const useNodeHeightCache = (): NodeHeightCache => {
+  const nodes = useRecoilValue(nodesState);
+  const ref = useRef<Record<string, number | undefined>>({});
+
+  const set = useCallback((nodeId: NodeId, height: number | undefined) => {
+    ref.current[nodeId] = height;
+  }, []);
+
+  const get = useCallback((nodeId: NodeId) => {
+    return ref.current[nodeId];
+  }, []);
+
+  const has = useCallback((nodeId: NodeId) => {
+    return nodeId in ref.current;
+  }, []);
+
+  return useMemo(() => {
+    const pre = ref.current;
+    ref.current = nodes.reduce((acc, next) => {
+      acc[next.id] = pre[next.id];
+      return acc;
+    }, {} as Record<string, number | undefined>);
+    return { set, get, has } satisfies NodeHeightCache;
+  }, [nodes, set, get, has]);
+};
+
+/**
+ * This hook persist the last known height of a node's body to the height cache, and can later use that last known
+ * height temporarily while the node is waiting for the body to be available.
+ */
+export const useNodeBodyHeight = (cache: NodeHeightCache, nodeId: NodeId, ready: boolean) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (ready) {
+      cache.set(nodeId, ref.current?.getBoundingClientRect().height);
+    }
+  }, [cache, nodeId, ready]);
+
+  return { ref, height: !ready && cache.has(nodeId) ? `${cache.get(nodeId)}px` : undefined };
+};

--- a/packages/app/src/hooks/useNodeBodyHeight.tsx
+++ b/packages/app/src/hooks/useNodeBodyHeight.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useRecoilValue } from 'recoil';
 import { nodesState } from '../state/graph';
 
-export interface NodeHeightCache {
+export interface HeightCache {
   get: (nodeId: NodeId) => number | undefined;
 
   has: (nodeId: NodeId) => boolean;
@@ -16,7 +16,7 @@ export interface NodeHeightCache {
  * body needs to be re-rendered in order to get its height. This cache allows us to avoid flickering when the node
  * is first rendered in the dragging list.
  */
-export const useNodeHeightCache = (): NodeHeightCache => {
+export const useNodeHeightCache = (): HeightCache => {
   const nodes = useRecoilValue(nodesState);
   const ref = useRef<Record<string, number | undefined>>({});
 
@@ -38,7 +38,7 @@ export const useNodeHeightCache = (): NodeHeightCache => {
       acc[next.id] = pre[next.id];
       return acc;
     }, {} as Record<string, number | undefined>);
-    return { set, get, has } satisfies NodeHeightCache;
+    return { set, get, has } satisfies HeightCache;
   }, [nodes, set, get, has]);
 };
 
@@ -46,14 +46,14 @@ export const useNodeHeightCache = (): NodeHeightCache => {
  * This hook persist the last known height of a node's body to the height cache, and can later use that last known
  * height temporarily while the node is waiting for the body to be available.
  */
-export const useNodeBodyHeight = (cache: NodeHeightCache, nodeId: NodeId, ready: boolean) => {
+export const useNodeBodyHeight = (heightCache: HeightCache, nodeId: NodeId, ready: boolean) => {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (ready) {
-      cache.set(nodeId, ref.current?.getBoundingClientRect().height);
+      heightCache.set(nodeId, ref.current?.getBoundingClientRect().height);
     }
-  }, [cache, nodeId, ready]);
+  }, [heightCache, nodeId, ready]);
 
-  return { ref, height: !ready && cache.has(nodeId) ? `${cache.get(nodeId)}px` : undefined };
+  return { ref, height: !ready && heightCache.has(nodeId) ? `${heightCache.get(nodeId)}px` : undefined };
 };


### PR DESCRIPTION
This PR closes #277 by uses a memory "cache" to store node heights. These heights are then used by the `UnknownNodeBody` component when the body is not yet available. This resolves the reported issue, because the components are unmounted and mounted when being moved in the DOM structure from the canvas to the dragging list and then back again. The flickering happens because the body component is rendered async and isn't ready on the first render pass. The cache acts as a "last known height" value when the body is not ready.

The fix is a bit hacky in nature. I tried my best to isolate it to separate hooks, and this approach seemed to have the smallest footprint of changes. It did require a "cache" prop to be prop drilled down to the `NodeBody` component. There is a `nodes.reduce()` call that rebuilds the cache when nodes change to prevent memory leaks. The performance seems to be fine as the the `nodes` dependency only changes when nodes are selected.

> Note: I couldn't figure out how `useUnknownNodeComponentDescriptorFor` worked, and only applied the height fix to the `UnknownNodeBody` component. It's possible other node types could use this fix as well. Maybe at a later date, when I know more, I can apply the fixes there.

Video recording __before__ the PR fix:

https://github.com/Ironclad/rivet/assets/50146659/9fe5586c-d654-4388-96e6-88af4be10bba

Video recording __after__ the PR fix:

https://github.com/Ironclad/rivet/assets/50146659/5a562b95-beb9-4efa-9e81-3f5fed43cf9d

