### PR TITLE
fix: a deconstruct error when drag end has no closest port

### DIFF
--- a/packages/app/src/hooks/useDraggingWire.ts
+++ b/packages/app/src/hooks/useDraggingWire.ts
@@ -69,7 +69,7 @@ export const useDraggingWire = (onConnectionsChanged: (connections: NodeConnecti
         return;
       }
 
-      const { nodeId: endNodeId, portId: endPortId } = closestPortToDraggingWire!;
+      const { nodeId: endNodeId, portId: endPortId } = closestPortToDraggingWire ?? {};
 
       if (!endNodeId || !endPortId) {
         return;


### PR DESCRIPTION
This PR closes #279 

It's a pretty simple fix.