### PR TITLE
fix: load failure when reloading a previous project

### DIFF
--- a/packages/app/src/components/ProjectSelector.tsx
+++ b/packages/app/src/components/ProjectSelector.tsx
@@ -349,7 +349,7 @@ export const ProjectTab: FC<{
   const project = openedProjects[projectId];
 
   const unsaved = !project?.fsPath;
-  const fileName = unsaved ? 'Unsaved' : project.fsPath.split('/').pop();
+  const fileName = unsaved ? 'Unsaved' : project.fsPath!.split('/').pop();
   const projectDisplayName = `${project?.project.metadata.title}${fileName ? ` [${fileName}]` : ''}`;
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/app/src/hooks/useLoadProject.ts
+++ b/packages/app/src/hooks/useLoadProject.ts
@@ -38,7 +38,7 @@ export function useLoadProject() {
       }
 
       setLoadedProjectState({
-        path: projectInfo.fsPath,
+        path: projectInfo.fsPath ?? '',
         loaded: true,
       });
 

--- a/packages/app/src/hooks/useLoadProjectWithFileBrowser.ts
+++ b/packages/app/src/hooks/useLoadProjectWithFileBrowser.ts
@@ -34,8 +34,8 @@ export function useLoadProjectWithFileBrowser() {
         if (alreadyOpenedProject) {
           toast.error(
             `"${alreadyOpenedProject.project.metadata.title} [${alreadyOpenedProject.fsPath
-              .split('/')
-              .pop()}]" shares the same ID (${
+              ?.split('/')
+              .pop() ?? 'no path'}]" shares the same ID (${
               project.metadata.id
             }) and is already open. Please close that project first to open this one.`,
           );

--- a/packages/app/src/hooks/useSyncCurrentStateIntoOpenedProjects.ts
+++ b/packages/app/src/hooks/useSyncCurrentStateIntoOpenedProjects.ts
@@ -83,7 +83,7 @@ export function useSyncCurrentStateIntoOpenedProjects() {
 
   // Sync current graph into opened projects when user switches projects.
   useEffect(() => {
-    if (prevProjectState.project != null && prevProjectState.project.metadata.id !== currentProject.metadata.id) {
+    if (prevProjectState.project != null && prevProjectState.project.metadata.id !== currentProject.metadata.id && openedProjects[prevProjectState.project.metadata.id]) {
       setOpenedProjects((openedProjects) => ({
         ...openedProjects,
         [prevProjectState.project.metadata.id]: {

--- a/packages/app/src/hooks/useSyncCurrentStateIntoOpenedProjects.ts
+++ b/packages/app/src/hooks/useSyncCurrentStateIntoOpenedProjects.ts
@@ -1,7 +1,8 @@
+import { type Project } from '@ironclad/rivet-core';
 import { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import {
-  loadedProjectState,
+  loadedProjectState, type OpenedProjectInfo,
   openedProjectsSortedIdsState,
   openedProjectsState,
   projectState,
@@ -24,7 +25,7 @@ export function useSyncCurrentStateIntoOpenedProjects() {
         [currentProject.metadata.id]: {
           project: currentProject,
           fsPath: null,
-        },
+        } satisfies OpenedProjectInfo,
       }));
     }
 
@@ -34,7 +35,7 @@ export function useSyncCurrentStateIntoOpenedProjects() {
         [currentProject.metadata.id]: {
           project: currentProject,
           fsPath: loadedProject.path,
-        },
+        } satisfies OpenedProjectInfo,
       }));
     }
 
@@ -51,7 +52,7 @@ export function useSyncCurrentStateIntoOpenedProjects() {
       [currentProject.metadata.id]: {
         ...openedProjects[currentProject.metadata.id],
         project: currentProject,
-      },
+      } satisfies OpenedProjectInfo,
     }));
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional
   }, [currentProject]);
@@ -60,7 +61,7 @@ export function useSyncCurrentStateIntoOpenedProjects() {
   const [prevProjectState, setPrevProjectState] = useState({
     project: currentProject,
     openedGraph: currentGraph?.metadata?.id,
-  });
+  } satisfies OpenedProjectInfo);
   useEffect(() => {
     if (
       currentGraph.metadata?.id != null &&
@@ -76,7 +77,7 @@ export function useSyncCurrentStateIntoOpenedProjects() {
           },
         },
         openedGraph: currentGraph.metadata!.id!,
-      });
+      } satisfies OpenedProjectInfo);
     }
   }, [currentGraph, currentProject, prevProjectState.project.metadata.id]);
 
@@ -89,13 +90,13 @@ export function useSyncCurrentStateIntoOpenedProjects() {
           ...openedProjects[prevProjectState.project.metadata.id],
           project: prevProjectState.project,
           openedGraph: prevProjectState.openedGraph,
-        },
+        } satisfies OpenedProjectInfo,
       }));
       // Update prevProjectState, so that we track changes to it
       setPrevProjectState({
         project: currentProject,
         openedGraph: currentGraph?.metadata?.id,
-      });
+      } satisfies OpenedProjectInfo);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional
   }, [currentProject]);

--- a/packages/app/src/hooks/useSyncCurrentStateIntoOpenedProjects.ts
+++ b/packages/app/src/hooks/useSyncCurrentStateIntoOpenedProjects.ts
@@ -1,13 +1,13 @@
-import { type Project } from '@ironclad/rivet-core';
 import { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
+import { graphState } from '../state/graph';
 import {
-  loadedProjectState, type OpenedProjectInfo,
+  loadedProjectState,
+  type OpenedProjectInfo,
   openedProjectsSortedIdsState,
   openedProjectsState,
   projectState,
 } from '../state/savedGraphs';
-import { graphState } from '../state/graph';
 
 export function useSyncCurrentStateIntoOpenedProjects() {
   const [openedProjects, setOpenedProjects] = useRecoilState(openedProjectsState);

--- a/packages/app/src/state/execution.ts
+++ b/packages/app/src/state/execution.ts
@@ -34,7 +34,7 @@ export const remoteDebuggerState = atom<RemoteDebuggerState>({
     remoteUploadAllowed: false,
     isInternalExecutor: false,
   },
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const loadedRecordingState = atom<{

--- a/packages/app/src/state/graph.ts
+++ b/packages/app/src/state/graph.ts
@@ -20,7 +20,7 @@ const { persistAtom } = recoilPersist({ key: 'graph' });
 export const graphState = atom<NodeGraph>({
   key: 'graphState',
   default: emptyNodeGraph(),
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const graphMetadataState = selector({

--- a/packages/app/src/state/graphBuilder.ts
+++ b/packages/app/src/state/graphBuilder.ts
@@ -34,7 +34,7 @@ export const canvasPositionState = atom<CanvasPosition>({
 export const lastCanvasPositionByGraphState = atom<Record<GraphId, CanvasPosition | undefined>>({
   key: 'lastCanvasPositionByGraph',
   default: {},
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const draggingNodesState = atom<ChartNode[]>({

--- a/packages/app/src/state/savedGraphs.ts
+++ b/packages/app/src/state/savedGraphs.ts
@@ -29,7 +29,7 @@ export const projectState = atom<Omit<Project, 'data'>>({
     graphs: {},
     plugins: [],
   },
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const projectDataState = atom<Record<DataId, string> | undefined>({
@@ -82,7 +82,7 @@ export const loadedProjectState = atom<{
     path: '',
     loaded: false,
   },
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const savedGraphsState = selector<NodeGraph[]>({
@@ -150,7 +150,7 @@ export const projectsState = atom<OpenedProjectsInfo>({
     openedProjects: {},
     openedProjectsSortedIds: [],
   },
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const openedProjectsState = selector({
@@ -195,5 +195,5 @@ export type ProjectContext = Record<
 export const projectContextState = atomFamily<ProjectContext, ProjectId>({
   key: 'projectContext',
   default: {},
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });

--- a/packages/app/src/state/savedGraphs.ts
+++ b/packages/app/src/state/savedGraphs.ts
@@ -135,7 +135,7 @@ export const projectPluginsState = selector({
 
 export type OpenedProjectInfo = {
   project: Project;
-  fsPath: string;
+  fsPath?: string | null;
   openedGraph?: GraphId;
 };
 

--- a/packages/app/src/state/settings.ts
+++ b/packages/app/src/state/settings.ts
@@ -17,7 +17,7 @@ export const settingsState = atom<Settings>({
     pluginEnv: {},
     pluginSettings: {},
   },
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const themes = [
@@ -40,19 +40,19 @@ export type Theme = (typeof themes)[number]['value'];
 export const themeState = atom<Theme>({
   key: 'theme',
   default: 'molten',
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const recordExecutionsState = atom<boolean>({
   key: 'recordExecutions',
   default: true,
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const defaultExecutorState = atom<'browser' | 'nodejs'>({
   key: 'defaultExecutor',
   default: 'browser',
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const executorOptions = isInTauri()
@@ -65,19 +65,19 @@ export const executorOptions = isInTauri()
 export const previousDataPerNodeToKeepState = atom<number>({
   key: 'previousDataPerNodeToKeep',
   default: -1,
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const checkForUpdatesState = atom<boolean>({
   key: 'checkForUpdates',
   default: true,
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const skippedMaxVersionState = atom<string | undefined>({
   key: 'skippedMaxVersion',
   default: undefined,
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const updateModalOpenState = atom<boolean>({
@@ -93,5 +93,5 @@ export const updateStatusState = atom<string | undefined>({
 export const zoomSensitivityState = atom<number>({
   key: 'zoomSensitivity',
   default: 0.25,
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });

--- a/packages/app/src/state/trivet.ts
+++ b/packages/app/src/state/trivet.ts
@@ -18,7 +18,7 @@ export const trivetState = atom<TrivetState>({
     testSuites: [],
     runningTests: false,
   },
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const trivetTestsRunningState = selector({

--- a/packages/app/src/state/ui.ts
+++ b/packages/app/src/state/ui.ts
@@ -25,7 +25,7 @@ export const newProjectModalOpenState = atom({
 export const expandedFoldersState = atom<Record<string, boolean>>({
   key: 'expandedFoldersState',
   default: {},
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });
 
 export const helpModalOpenState = atom<boolean>({

--- a/packages/app/src/state/userInput.ts
+++ b/packages/app/src/state/userInput.ts
@@ -30,5 +30,5 @@ export const userInputModalSubmitState = atom<{
 export const lastAnswersState = atom<Record<string, string>>({
   key: 'lastAnswers',
   default: {},
-  effects_UNSTABLE: [persistAtom],
+  effects: [persistAtom],
 });


### PR DESCRIPTION
This PR closes #282 

## Steps to reproduce bug

- have multiple projects open
- select a project tab
- close that project tab
- reopen that project from file

## Reason

The act of "closing the currently selected tab" caused a bug where the "currentProject" is removed from Recoil, but then in a `useEffect()` that closed project would get added back to "openProjects". It was a simple logic problem on trying to remember the previous project.

> Note: this PR also replaces "effects_UNSTABLE" with "effects" as it's now a stable feature of Recoil