### PR TITLE
fix: Mitigating undefined bug in `alreadyOpenedProject.fsPath` 

### DIFF
--- a/packages/app/src/hooks/useLoadProjectWithFileBrowser.ts
+++ b/packages/app/src/hooks/useLoadProjectWithFileBrowser.ts
@@ -31,11 +31,10 @@ export function useLoadProjectWithFileBrowser() {
           (p) => p.project.metadata.id === project.metadata.id,
         );
 
-        if (alreadyOpenedProject && alreadyOpenedProject.fsPath) {
+        if (alreadyOpenedProject) {
+          const projectPath = alreadyOpenedProject.fsPath?.split('/').pop() ?? '';
           toast.error(
-            `"${alreadyOpenedProject.project.metadata.title} [${alreadyOpenedProject.fsPath
-              .split('/')
-              .pop()}]" shares the same ID (${
+            `"${alreadyOpenedProject.project.metadata.title} [${projectPath}]" shares the same ID (${
               project.metadata.id
             }) and is already open. Please close that project first to open this one.`,
           );

--- a/packages/app/src/hooks/useLoadProjectWithFileBrowser.ts
+++ b/packages/app/src/hooks/useLoadProjectWithFileBrowser.ts
@@ -31,7 +31,7 @@ export function useLoadProjectWithFileBrowser() {
           (p) => p.project.metadata.id === project.metadata.id,
         );
 
-        if (alreadyOpenedProject) {
+        if (alreadyOpenedProject && alreadyOpenedProject.fsPath) {
           toast.error(
             `"${alreadyOpenedProject.project.metadata.title} [${alreadyOpenedProject.fsPath
               .split('/')


### PR DESCRIPTION
- When using `File > Open Project` we were encountering an undefined value when trying to parse `alreadyOpenedProject.fsPath` 
- We can mitigate this by placing another check to make sure that the field `fsPath` exists in `alreadyOpenedProject`

Error:
<img width="369" alt="Screenshot 2024-01-11 at 1 42 46 PM" src="https://github.com/Ironclad/rivet/assets/107009412/7c064088-3948-4d0d-8ff6-d8074efaf1c2">
