### PR TITLE
Object node can return arrays

### DIFF
--- a/packages/core/src/model/nodes/ObjectNode.ts
+++ b/packages/core/src/model/nodes/ObjectNode.ts
@@ -61,7 +61,7 @@ export class ObjectNodeImpl extends NodeImpl<ObjectNode> {
   getOutputDefinitions(): NodeOutputDefinition[] {
     return [
       {
-        dataType: 'object',
+        dataType: ['object', 'object[]'],
         id: 'output' as PortId,
         title: 'Output',
       },
@@ -125,6 +125,15 @@ export class ObjectNodeImpl extends NodeImpl<ObjectNode> {
       string,
       unknown
     >;
+
+    if (Array.isArray(outputValue)) {
+      return {
+        output: {
+          type: 'object[]',
+          value: outputValue,
+        },
+      };
+    }
 
     return {
       output: {


### PR DESCRIPTION
Inspect the output type of the object node and if it's an array, return a more-appropriate `object[]` type rather than `object`. Fixes #305 