### PR TITLE
When coercing an object to a string, infer the type based on the value

### DIFF
--- a/packages/core/src/utils/coerceType.ts
+++ b/packages/core/src/utils/coerceType.ts
@@ -168,7 +168,8 @@ function coerceToString(value: DataValue | undefined): string | undefined {
   }
 
   // Don't know, so try to infer it from the type of the value
-  if (value.type === 'any') {
+  // Any and object are basically the same...
+  if (value.type === 'any' || value.type === 'object') {
     const inferred = inferType(value.value);
     return coerceTypeOptional(inferred, 'string');
   }
@@ -317,12 +318,7 @@ function coerceToNumber(value: DataValue | undefined): number | undefined {
     return undefined;
   }
 
-  if (value.type === 'any') {
-    const inferred = inferType(value.value);
-    return coerceTypeOptional(inferred, 'number');
-  }
-
-  if (value.type === 'object') {
+  if (value.type === 'any' || value.type === 'object') {
     const inferred = inferType(value.value);
     return coerceTypeOptional(inferred, 'number');
   }


### PR DESCRIPTION
Basically treat `object` and `any` the same, unfortunately, because the object node outputs object, but it can also output an array, and also an array of strings.... Basically I think this is just the least-bad fix for `object` and `any` to be nearly the same.

Fixes #307 