### PR TITLE
Retry OpenAI API 408 timeout

### DIFF
--- a/packages/core/src/model/nodes/ChatNode.ts
+++ b/packages/core/src/model/nodes/ChatNode.ts
@@ -1047,6 +1047,18 @@ export class ChatNodeImpl extends NodeImpl<ChatNode> {
               }
             }
 
+            if (err.status === 408) {
+              if (retriesLeft) {
+                context.onPartialOutputs?.({
+                  ['response' as PortId]: {
+                    type: 'string',
+                    value: 'OpenAI API timed out, retrying...',
+                  },
+                });
+                return;
+              }
+            }
+
             // We did something wrong (besides rate limit)
             if (err.status >= 400 && err.status < 500) {
               throw new Error(err.message);


### PR DESCRIPTION
Have been getting this error intermittently when my graph runs:

`Graph xxx/xxx (xxx) failed to process due to errors in nodes: xxx (xxx): Error: Graph Response xxx (xxx) failed to process due to errors in nodes: xxx (xxx): Error: Error processing ChatNode: OpenAIError: 408 {"error":{"code":"Timeout","message":"The operation was timeout."}}`

From googling, can only find mentions of 408 errors from people using Azure OpenAI deployments, which might explain why other people haven't bumped into this. But yeah handling it in the same way as a rate limiting error (just retrying) makes sense to me.