### PR TITLE
fix: ignore empty event lines

### DIFF
--- a/packages/core/src/utils/fetchEventSource.ts
+++ b/packages/core/src/utils/fetchEventSource.ts
@@ -123,14 +123,16 @@ function createEventStream(body: ReadableStream<Uint8Array> | null) {
   const eventStream = textStream.pipeThrough(new TransformStream(new LineSplitter())).pipeThrough(
     new TransformStream<string, string>({
       transform(line, controller) {
+        if (line.trim().length === 0) {
+          return;
+        }
+
         if (line.startsWith('data: ')) {
           const data = line.slice(6).trim();
           controller.enqueue(data);
         } else if (line.startsWith('event: ')) {
           const event = line.slice(7).trim();
           controller.enqueue(`[${event}]`);
-        } else {
-          console.log('Unknown event source line: ', line);
         }
       },
     }),


### PR DESCRIPTION
## Description

The Event Stream implementation was printing log in the console when an empty line was received.

I ignored the empty lines and also removed the log because it can flood log manager of production servers.