### PR TITLE
Anthropic Claude 3 support (Sonnet, Opus, Haiku, and Vision)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,14 +74,21 @@ In VS Code, ESLint is configured to run automatically on save. We also recommend
 
 ## Node Executor
 
-Certain nodes need to run in the "Node Executor." This starts a "sidecar" process, which can be difficult to develop with. If you are developing a feature or plugin that requires the Node Executor, consider running the node executor directly:
+Certain nodes need to run in the "Node Executor." This starts a "sidecar" process, which can be difficult to develop with. If you are developing a feature or plugin that requires the Node Executor, consider using the following setup:
+
+Run a watcher for code changes:
+
+```
+cd packages/core
+yarn watch
+```
+
+Then, start the app-executor in dev mode:
 
 ```
 cd packages/app-executor
-yarn start --port 21889
+yarn dev
 ```
-
-This will reduce the build time. However, you will still need to restart the sidecar whenever you make a code change.
 
 ## Releasing
 

--- a/packages/app-executor/bin/executor.mts
+++ b/packages/app-executor/bin/executor.mts
@@ -154,4 +154,8 @@ const rivetDebugger = startDebuggerServer({
   },
 });
 
+process.on('SIGTERM', () => {
+  rivetDebugger.webSocketServer.close();
+});
+
 console.log(`Node.js executor started on port ${port}.`);

--- a/packages/app-executor/package.json
+++ b/packages/app-executor/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsx scripts/build-executor.mts",
+    "dev": "tsx watch --inspect=9228 --experimental-network-imports bin/executor.mts",
     "start": "yarn build && node --experimental-network-imports bin/executor-bundle.cjs",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx,.mts bin"
   },

--- a/packages/core/bundle.esbuild.ts
+++ b/packages/core/bundle.esbuild.ts
@@ -19,7 +19,7 @@ const aliasModule = (moduleFrom: string, moduleTo: string): esbuild.Plugin => ({
   },
 });
 
-esbuild.build({
+const options: esbuild.BuildOptions = {
   entryPoints: ['src/index.ts'],
   bundle: true,
   platform: 'node',
@@ -27,10 +27,18 @@ esbuild.build({
   format: 'cjs',
   target: 'node16',
   packages: 'external',
+  sourcemap: true,
   plugins: [
     aliasModule('lodash-es', 'lodash'),
     aliasModule('p-queue', 'p-queue-6'),
     aliasModule('emittery', 'emittery-0-13'),
     aliasModule('p-retry', 'p-retry-4'),
   ],
-});
+};
+
+if (process.argv.includes('--watch')) {
+  const context = await esbuild.context(options);
+  await context.watch();
+} else {
+  await esbuild.build(options);
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,8 @@
     "prepack": "yarn build && cp -r ../../LICENSE ../../README.md .",
     "publish": "yarn npm publish --access public",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./src",
-    "test": "tsx --test test/**/*.test.ts"
+    "test": "tsx --test test/**/*.test.ts",
+    "watch": "tsc -b -w"
   },
   "dependencies": {
     "@gentrace/core": "^2.2.5",

--- a/packages/core/src/plugins/anthropic/anthropic.ts
+++ b/packages/core/src/plugins/anthropic/anthropic.ts
@@ -149,7 +149,7 @@ export const anthropic = {
 
       const defaultSignal = new AbortController().signal;
 
-      const requestBody = {
+      const requestBody: ChatCompletionOptionsWithImage = {
         model,
         prompt,
         max_tokens_to_sample,
@@ -161,7 +161,7 @@ export const anthropic = {
       };
 
       if (image) {
-        requestBody['image'] = image;
+        requestBody.image = image;
       }
 
       const response = await fetch('https://api.anthropic.com/v1/messages', {
@@ -189,4 +189,12 @@ export const anthropic = {
       };
     },
   },
+};
+
+export type ChatCompletionOptionsWithImage = ChatCompletionOptions & {
+  image?: {
+    type: string;
+    media_type: string;
+    data: string;
+  };
 };

--- a/packages/core/src/plugins/anthropic/anthropic.ts
+++ b/packages/core/src/plugins/anthropic/anthropic.ts
@@ -34,6 +34,22 @@ export const anthropicModels = {
     },
     displayName: 'Claude 2.1',
   },
+  'claude-3-sonnet-20240229': {
+    maxTokens: 200_000,
+    cost: {
+      prompt: 0.000003,
+      completion: 0.000015,
+    },
+    displayName: 'Claude 3 Sonnet',
+  },
+  'claude-3-opus-20240229': {
+    maxTokens: 200_000,
+    cost: {
+      prompt: 0.000015,
+      completion: 0.000075,
+    },
+    displayName: 'Claude 3 Opus',
+  },
 } satisfies Record<string, AnthropicModel>;
 
 export type AnthropicModels = keyof typeof anthropicModels;

--- a/packages/core/src/plugins/anthropic/anthropic.ts
+++ b/packages/core/src/plugins/anthropic/anthropic.ts
@@ -150,6 +150,7 @@ export const anthropic = {
       const defaultSignal = new AbortController().signal;
 
       const requestBody: ChatCompletionOptionsWithImage = {
+        apiKey,
         model,
         prompt,
         max_tokens_to_sample,

--- a/packages/core/src/plugins/anthropic/anthropic.ts
+++ b/packages/core/src/plugins/anthropic/anthropic.ts
@@ -18,46 +18,54 @@ export const anthropicModels = {
     },
     displayName: 'Claude Instant',
   },
+  'claude-instant-1.2': {
+    maxTokens: 100_000,
+    cost: {
+      prompt: 0.8e-6,
+      completion: 2.4e-6,
+    },
+    displayName: 'Claude Instant 1.2',
+  },
   'claude-2': {
     maxTokens: 100_000,
     cost: {
-      prompt: 0.01102,
-      completion: 0.03268,
+      prompt: 8e-6,
+      completion: 24e-6,
     },
     displayName: 'Claude 2',
   },
   'claude-2.1': {
     maxTokens: 200_000,
     cost: {
-      prompt: 0.01102,
-      completion: 0.03268,
+      prompt: 8e-6,
+      completion: 24e-6,
     },
     displayName: 'Claude 2.1',
+  },
+  'claude-3-haiku-20240307': {
+    maxTokens: 200_000,
+    cost: {
+      prompt: 0.25e-6,
+      completion: 1.25e-6,
+    },
+    displayName: 'Claude 3 Haiku',
   },
   'claude-3-sonnet-20240229': {
     maxTokens: 200_000,
     cost: {
-      prompt: 0.000003,
-      completion: 0.000015,
+      prompt: 3e-6,
+      completion: 15e-6,
     },
     displayName: 'Claude 3 Sonnet',
   },
   'claude-3-opus-20240229': {
     maxTokens: 200_000,
     cost: {
-      prompt: 0.000015,
-      completion: 0.000075,
+      prompt: 15e-6,
+      completion: 75e-6,
     },
     displayName: 'Claude 3 Opus',
   },
-  'claude-3-haiku-20240307': {
-    maxTokens: 200_000,
-    cost: {
-      prompt: 2.5e-7,
-      completion: 1.25e-6,
-    },
-    displayName: 'Claude 3 Haiku',
-  }
 } satisfies Record<string, AnthropicModel>;
 
 export type AnthropicModels = keyof typeof anthropicModels;
@@ -212,7 +220,7 @@ export async function* streamChatCompletions({
   }
 }
 
-export async function* streamClaude3ChatCompletions({
+export async function* streamMessageApi({
   apiKey,
   signal,
   ...rest

--- a/packages/core/src/plugins/anthropic/anthropic.ts
+++ b/packages/core/src/plugins/anthropic/anthropic.ts
@@ -50,6 +50,14 @@ export const anthropicModels = {
     },
     displayName: 'Claude 3 Opus',
   },
+  'claude-3-haiku-20240307': {
+    maxTokens: 200_000,
+    cost: {
+      prompt: 2.5e-7,
+      completion: 1.25e-6,
+    },
+    displayName: 'Claude 3 Haiku',
+  }
 } satisfies Record<string, AnthropicModel>;
 
 export type AnthropicModels = keyof typeof anthropicModels;

--- a/packages/core/src/plugins/anthropic/anthropic.ts
+++ b/packages/core/src/plugins/anthropic/anthropic.ts
@@ -69,6 +69,11 @@ export type ChatCompletionOptions = {
   top_p?: number;
   top_k?: number;
   signal?: AbortSignal;
+  image?: {
+    type: string;
+    media_type: string;
+    data: string;
+  };
 };
 
 export type ChatCompletionChunk = {

--- a/packages/core/src/plugins/anthropic/anthropic.ts
+++ b/packages/core/src/plugins/anthropic/anthropic.ts
@@ -197,4 +197,5 @@ export type ChatCompletionOptionsWithImage = ChatCompletionOptions & {
     media_type: string;
     data: string;
   };
+  stream?: boolean;
 };

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -181,15 +181,19 @@ export const ChatAnthropicNodeImpl: PluginNodeImpl<ChatAnthropicNode> = {
 
   getBody(data): string {
     return dedent`
-      ${
-        data.model === 'claude-2'
-          ? 'Claude 2'
-          : data.model === 'claude-2.1'
-            ? 'Claude 2.1'
-            : data.model.startsWith('claude-instant')
-              ? 'Claude Instant'
-              : 'Unknown Model'
-      }
+    ${
+      data.model === 'claude-2'
+        ? 'Claude 2'
+        : data.model === 'claude-2.1'
+          ? 'Claude 2.1'
+          : data.model === 'claude-3-opus-20240229'
+            ? 'Claude 3 Opus'
+            : data.model === 'claude-3-sonnet-20240229'
+              ? 'Claude 3 Sonnet'
+              : data.model.startsWith('claude-instant')
+                ? 'Claude Instant'
+                : 'Unknown Model'
+    }
       ${
         data.useTopP
           ? `Top P: ${data.useTopPInput ? '(Using Input)' : data.top_p}`

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -288,7 +288,7 @@ export const ChatAnthropicNodeImpl: PluginNodeImpl<ChatAnthropicNode> = {
     };
   },
 
-  async process(data, inputs: Inputs, context: InternalProcessContext): Promise<Outputs> {
+async process(data, inputs: Inputs, context: InternalProcessContext): Promise<Outputs> {
   const output: Outputs = {};
   const rawModel = data.useModelInput
     ? coerceTypeOptional(inputs['model' as PortId], 'string') ?? data.model
@@ -357,7 +357,7 @@ export const ChatAnthropicNodeImpl: PluginNodeImpl<ChatAnthropicNode> = {
           ],
           temperature: useTopP ? undefined : temperature,
           top_p: useTopP ? topP : undefined,
-          max_tokens,
+          max_tokens: maxTokens,
           stop_sequences: stop ? [stop] : undefined,
         };
         const cacheKey = JSON.stringify(options);

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -385,6 +385,8 @@ return await retry(
           
           if (model.startsWith('claude-3')) {
             const image = inputs['image' as PortId];
+            let responseParts: string[] = [];
+          
             if (image && image.type === 'image') {
               // Use the Messages API for Claude 3 models with Vision
               const response = await anthropic.messages.create({
@@ -412,7 +414,6 @@ return await retry(
               });
           
               // Process the response chunks and update the output
-              const responseParts: string[] = [];
               for await (const chunk of chunks) {
                 if (!chunk.completion) {
                   continue;
@@ -449,7 +450,7 @@ return await retry(
           }
           
           const endTime = Date.now();
-
+          
           if (model.startsWith('claude-3') && image) {
             // Skip token count and duration for Claude 3 models with Vision
           } else {

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -300,10 +300,11 @@ export const ChatAnthropicNodeImpl: PluginNodeImpl<ChatAnthropicNode> = {
       : data.stop;
     const { messages } = await getChatAnthropicNodeMessages(inputs);
     let prompt = messages.reduce((acc, message) => {
+      const content = typeof message.content === 'string' ? message.content : message.content.map((c) => c.text ?? '').join('');
       if (message.role === 'user') {
-        return `${acc}\n\nHuman: ${message.content}`;
+        return `${acc}\n\nHuman: ${content}`;
       } else if (message.role === 'assistant') {
-        return `${acc}\n\nAssistant: ${message.content}`;
+        return `${acc}\n\nAssistant: ${content}`;
       }
       return acc;
     }, '');

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -383,34 +383,56 @@ return await retry(
           const startTime = Date.now();
           const apiKey = context.getPluginConfig('anthropicApiKey');
           
-        if (model.startsWith('claude-3')) {
-          const image = inputs['image' as PortId];
-          if (image && image.type === 'image') {
-            // Use the Messages API for Claude 3 models with Vision
-            const response = await anthropic.messages.create({
-              apiKey: apiKey ?? '',
-              signal: context.signal,
-              ...options,
-              image: {
-                type: 'base64',
-                media_type: image.value.mediaType,
-                data: image.value.data.toString('base64'),
-              },
-            });
-        
-            // Process the response and update the output
-            output['response' as PortId] = {
-              type: 'string',
-              value: response.completion.trim(),
-            };
+          if (model.startsWith('claude-3')) {
+            const image = inputs['image' as PortId];
+            if (image && image.type === 'image') {
+              // Use the Messages API for Claude 3 models with Vision
+              const response = await anthropic.messages.create({
+                apiKey: apiKey ?? '',
+                signal: context.signal,
+                ...options,
+                image: {
+                  type: 'base64',
+                  media_type: image.value.mediaType,
+                  data: image.value.data.toString(),
+                },
+              });
+          
+              // Process the response and update the output
+              output['response' as PortId] = {
+                type: 'string',
+                value: response.completion.trim(),
+              };
+            } else {
+              // Use the normal chat completion method for Claude 3 models without Vision
+              const chunks = streamChatCompletions({
+                apiKey: apiKey ?? '',
+                signal: context.signal,
+                ...options,
+              });
+          
+              // Process the response chunks and update the output
+              const responseParts: string[] = [];
+              for await (const chunk of chunks) {
+                if (!chunk.completion) {
+                  continue;
+                }
+                responseParts.push(chunk.completion);
+                output['response' as PortId] = {
+                  type: 'string',
+                  value: responseParts.join('').trim(),
+                };
+                context.onPartialOutputs?.(output);
+              }
+            }
           } else {
-            // Use the normal chat completion method for Claude 3 models without Vision
+            // Use the normal chat completion method for non-Claude 3 models
             const chunks = streamChatCompletions({
               apiKey: apiKey ?? '',
               signal: context.signal,
               ...options,
             });
-        
+          
             // Process the response chunks and update the output
             const responseParts: string[] = [];
             for await (const chunk of chunks) {
@@ -425,28 +447,6 @@ return await retry(
               context.onPartialOutputs?.(output);
             }
           }
-        } else {
-          // Use the normal chat completion method for non-Claude 3 models
-          const chunks = streamChatCompletions({
-            apiKey: apiKey ?? '',
-            signal: context.signal,
-            ...options,
-          });
-        
-          // Process the response chunks and update the output
-          const responseParts: string[] = [];
-          for await (const chunk of chunks) {
-            if (!chunk.completion) {
-              continue;
-            }
-            responseParts.push(chunk.completion);
-            output['response' as PortId] = {
-              type: 'string',
-              value: responseParts.join('').trim(),
-            };
-            context.onPartialOutputs?.(output);
-          }
-        }
           
           const endTime = Date.now();
 

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -174,6 +174,12 @@ export const ChatAnthropicNodeImpl: PluginNodeImpl<ChatAnthropicNode> = {
         id: 'image' as PortId,
         title: 'Image',
       });
+    // Add the "System" prompt input port for Claude 3 models
+      inputs.push({
+        dataType: 'string',
+        id: 'system' as PortId,
+        title: 'System',
+      });
     }
 
   return inputs;
@@ -316,6 +322,10 @@ async process(data, inputs: Inputs, context: InternalProcessContext): Promise<Ou
     return acc;
   }, '');
   prompt += '\n\nAssistant:';
+  
+  // Get the "System" prompt input for Claude 3 models
+  const system = data.model.startsWith('claude-3') ? coerceTypeOptional(inputs['system' as PortId], 'string') : undefined;
+  
   let { maxTokens } = data;
   const tokenizerInfo: TokenizerCallInfo = {
     node: context.node,
@@ -359,6 +369,8 @@ async process(data, inputs: Inputs, context: InternalProcessContext): Promise<Ou
           top_p: useTopP ? topP : undefined,
           max_tokens: maxTokens,
           stop_sequences: stop ? [stop] : undefined,
+          // Include the "System" prompt for Claude 3 models
+          system: system,
         };
         const cacheKey = JSON.stringify(options);
         if (data.cache) {

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -377,13 +377,11 @@ export const ChatAnthropicNodeImpl: PluginNodeImpl<ChatAnthropicNode> = {
           if (model.startsWith('claude-3')) {
             const image = inputs['image' as PortId];
             if (image && image.type === 'image') {
-              options.images = [
-                {
-                  type: 'base64',
-                  media_type: image.value.mediaType,
-                  data: image.value.data,
-                },
-              ];
+              options.image = {
+                type: 'base64',
+                media_type: image.value.mediaType,
+                data: image.value.data,
+              };
             }
           }
 

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -451,9 +451,10 @@ return await retry(
         
         const endTime = Date.now();
         
-        if (model.startsWith('claude-3') && image) {
+        if (model.startsWith('claude-3') && Image) {
           // Skip token count and duration for Claude 3 models with Vision
         } else {
+          let responseParts: string[] = [];
           if (responseParts.length === 0) {
             throw new Error('No response from Anthropic');
           }

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -164,8 +164,19 @@ export const ChatAnthropicNodeImpl: PluginNodeImpl<ChatAnthropicNode> = {
       title: 'Prompt',
     });
 
-    return inputs;
-  },
+    // Claude Vision
+    // Add an image input port if Claude 3 is selected
+    // This is required to support Claude's Vision capabilities
+    if (data.model.startsWith('claude-3')) {
+      inputs.push({
+        dataType: 'image',
+        id: 'image' as PortId,
+        title: 'Image',
+      });
+    }
+
+  return inputs;
+},
 
   getOutputDefinitions(_data): NodeOutputDefinition[] {
     const outputs: NodeOutputDefinition[] = [];
@@ -359,6 +370,23 @@ export const ChatAnthropicNodeImpl: PluginNodeImpl<ChatAnthropicNode> = {
             max_tokens_to_sample: maxTokens,
             stop_sequences: stop ? [stop] : undefined,
           };
+
+          // Claude Vision
+          // Include the image data in the API options if the Claude 3 and an image input is provided
+          // This is necessary to send the image data to the Claude's Vision-capable models
+          if (model.startsWith('claude-3')) {
+            const image = inputs['image' as PortId];
+            if (image && image.type === 'image') {
+              options.images = [
+                {
+                  type: 'base64',
+                  media_type: image.value.mediaType,
+                  data: image.value.data,
+                },
+              ];
+            }
+          }
+
           const cacheKey = JSON.stringify(options);
 
           if (data.cache) {

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -20,6 +20,7 @@ import {
   anthropicModels,
   streamChatCompletions,
   AnthropicError,
+  anthropic
 } from '../anthropic.js';
 import { nanoid } from 'nanoid/non-secure';
 import { dedent } from 'ts-dedent';
@@ -362,111 +363,107 @@ export const ChatAnthropicNodeImpl: PluginNodeImpl<ChatAnthropicNode> = {
     try {
 return await retry(
   async () => {
-    const options: Omit<ChatCompletionOptions, 'apiKey' | 'signal'> = {
-      prompt,
-      model,
-      temperature: useTopP ? undefined : temperature,
-      top_p: useTopP ? topP : undefined,
-      max_tokens_to_sample: maxTokens,
-      stop_sequences: stop ? [stop] : undefined,
-    };
-    
-    const cacheKey = JSON.stringify(options);
-    if (data.cache) {
-      const cached = cache.get(cacheKey);
-      if (cached) {
-        return cached;
-      }
-    }
-    
-    const startTime = Date.now();
-    const apiKey = context.getPluginConfig('anthropicApiKey');
-    
-    if (model.startsWith('claude-3')) {
-      const image = inputs['image' as PortId];
-      if (image && image.type === 'image') {
-        // Use the Messages API for Claude 3 models with Vision
-        const response = await anthropic.messages.create({
-          apiKey: apiKey ?? '',
-          signal: context.signal,
-          ...options,
-          image: {
-            type: 'base64',
-            media_type: image.value.mediaType,
-            data: image.value.data,
-          },
-        });
-    
-        // Process the response and update the output
-        output['response' as PortId] = {
-          type: 'string',
-          value: response.completion.trim(),
-        };
-      } else {
-        // Use the normal chat completion method for Claude 3 models without Vision
-        const chunks = streamChatCompletions({
-          apiKey: apiKey ?? '',
-          signal: context.signal,
-          ...options,
-        });
-    
-        // Process the response chunks and update the output
-        const responseParts: string[] = [];
-        for await (const chunk of chunks) {
-          if (!chunk.completion) {
-            continue;
-          }
-          responseParts.push(chunk.completion);
-          output['response' as PortId] = {
-            type: 'string',
-            value: responseParts.join('').trim(),
+          const options: Omit<ChatCompletionOptions, 'apiKey' | 'signal'> = {
+            prompt,
+            model,
+            temperature: useTopP ? undefined : temperature,
+            top_p: useTopP ? topP : undefined,
+            max_tokens_to_sample: maxTokens,
+            stop_sequences: stop ? [stop] : undefined,
           };
-          context.onPartialOutputs?.(output);
-        }
-      }
-    } else {
-      // Use the normal chat completion method for non-Claude 3 models
-      const chunks = streamChatCompletions({
-        apiKey: apiKey ?? '',
-        signal: context.signal,
-        ...options,
-      });
-    
-      // Process the response chunks and update the output
-      const responseParts: string[] = [];
-      for await (const chunk of chunks) {
-        if (!chunk.completion) {
-          continue;
-        }
-        responseParts.push(chunk.completion);
-        output['response' as PortId] = {
-          type: 'string',
-          value: responseParts.join('').trim(),
-        };
-        context.onPartialOutputs?.(output);
-      }
-    }
-
+          
+          const cacheKey = JSON.stringify(options);
+          if (data.cache) {
+            const cached = cache.get(cacheKey);
+            if (cached) {
+              return cached;
+            }
+          }
+          
+          const startTime = Date.now();
+          const apiKey = context.getPluginConfig('anthropicApiKey');
+          
+          if (model.startsWith('claude-3')) {
+            const image = inputs['image' as PortId];
+            if (image && image.type === 'image') {
+              // Use the Messages API for Claude 3 models with Vision
+              const response = await anthropic.messages.create({
+                apiKey: apiKey ?? '',
+                signal: context.signal,
+                ...options,
+                image: {
+                  type: 'base64',
+                  media_type: image.value.mediaType,
+                  data: image.value.data,
+                },
+              });
+          
+              // Process the response and update the output
+              output['response' as PortId] = {
+                type: 'string',
+                value: response.completion.trim(),
+              };
+            } else {
+              // Use the normal chat completion method for Claude 3 models without Vision
+              const chunks = streamChatCompletions({
+                apiKey: apiKey ?? '',
+                signal: context.signal,
+                ...options,
+              });
+          
+              // Process the response chunks and update the output
+              const responseParts: string[] = [];
+              for await (const chunk of chunks) {
+                if (!chunk.completion) {
+                  continue;
+                }
+                responseParts.push(chunk.completion);
+                output['response' as PortId] = {
+                  type: 'string',
+                  value: responseParts.join('').trim(),
+                };
+                context.onPartialOutputs?.(output);
+              }
+            }
+          } else {
+            // Use the normal chat completion method for non-Claude 3 models
+            const chunks = streamChatCompletions({
+              apiKey: apiKey ?? '',
+              signal: context.signal,
+              ...options,
+            });
+          
+            // Process the response chunks and update the output
+            const responseParts: string[] = [];
+            for await (const chunk of chunks) {
+              if (!chunk.completion) {
+                continue;
+              }
+              responseParts.push(chunk.completion);
+              output['response' as PortId] = {
+                type: 'string',
+                value: responseParts.join('').trim(),
+              };
+              context.onPartialOutputs?.(output);
+            }
+          }
+          
           const endTime = Date.now();
 
-          if (responseParts.length === 0) {
-            throw new Error('No response from Anthropic');
+          if (model.startsWith('claude-3') && image) {
+            // Skip token count and duration for Claude 3 models with Vision
+          } else {
+            if (responseParts.length === 0) {
+              throw new Error('No response from Anthropic');
+            }
+          
+            output['requestTokens' as PortId] = { type: 'number', value: tokenCount };
+            const responseTokenCount = context.tokenizer.getTokenCountForString(responseParts.join(''), tokenizerInfo);
+            output['responseTokens' as PortId] = { type: 'number', value: responseTokenCount };
+          
+            const duration = endTime - startTime;
+            output['duration' as PortId] = { type: 'number', value: duration };
           }
-
-          output['requestTokens' as PortId] = { type: 'number', value: tokenCount };
-
-          const responseTokenCount = context.tokenizer.getTokenCountForString(responseParts.join(''), tokenizerInfo);
-          output['responseTokens' as PortId] = { type: 'number', value: responseTokenCount };
-
-          // TODO
-          // const cost =
-          //   getCostForPrompt(completionMessages, model) + getCostForTokens(responseTokenCount, 'completion', model);
-
-          // output['cost' as PortId] = { type: 'number', value: cost };
-
-          const duration = endTime - startTime;
-
-          output['duration' as PortId] = { type: 'number', value: duration };
 
           Object.freeze(output);
           cache.set(cacheKey, output);

--- a/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
+++ b/packages/core/src/plugins/anthropic/nodes/ChatAnthropicNode.ts
@@ -195,20 +195,9 @@ export const ChatAnthropicNodeImpl: PluginNodeImpl<ChatAnthropicNode> = {
   },
 
   getBody(data): string {
+    const modelName = anthropicModels[data.model]?.displayName ?? 'Unknown Model';
     return dedent`
-    ${
-      data.model === 'claude-2'
-        ? 'Claude 2'
-        : data.model === 'claude-2.1'
-          ? 'Claude 2.1'
-          : data.model === 'claude-3-opus-20240229'
-            ? 'Claude 3 Opus'
-            : data.model === 'claude-3-sonnet-20240229'
-              ? 'Claude 3 Sonnet'
-              : data.model.startsWith('claude-instant')
-                ? 'Claude Instant'
-                : 'Unknown Model'
-    }
+      ${modelName}
       ${
         data.useTopP
           ? `Top P: ${data.useTopPInput ? '(Using Input)' : data.top_p}`

--- a/packages/docs/docs/user-guide/plugins/built-in/anthropic.md
+++ b/packages/docs/docs/user-guide/plugins/built-in/anthropic.md
@@ -29,8 +29,9 @@ The Chat (Anthropic) node allows you to use the Claude API to generate text.
 
 | Title  | Data Type                                                    | Description                                       | Default Value | Notes                                                                                                                                                      |
 | ------ | ------------------------------------------------------------ | ------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Prompt | `string` or `string[]` or `chat-message` or `chat-message[]` | The messages to send to Claude to get a response. | (Required)    | Claude does not support a system prompt like GPT does, so you may have to get inventive to place words into Claude's mouth using Prompt nodes set to `AI`. |
+| Prompt | `string` or `string[]` or `chat-message` or `chat-message[]` | The messages to send to Claude to get a response. | (Required)    | Claude Instant and Claude 2.0 does not support a system prompt like GPT does, so you may have to get inventive to place words into Claude's mouth using Prompt nodes set to `AI`. |
 | Image | `image` | An image to send to Claude for analysis. | (Optional) | This input is only available when using a Claude 3 model (Claude 3 Opus or Claude 3 Sonnet). |
+| System  | `string`                                                     | A system prompt to provide context and instructions to Claude. This input is only available when using a Claude 3 model.    | (Optional)    | Use the system prompt to specify a particular goal or role for Claude. See the [guide to system prompts](https://docs.anthropic.com) for more information.  |
 
 #### Outputs
 
@@ -55,5 +56,6 @@ To use Vision with Claude 3 models:
 1. Select a Claude 3 model (Claude 3 Opus or Claude 3 Sonnet) in the node settings.
 2. Connect an image to the `Image` input of the Chat (Anthropic) node.
 3. Provide a text prompt that instructs Claude on how to analyze the image.
-4. Execute the node to receive Claude's response based on the provided image and text prompt.
-Note that the `Image` input is only available when using a Claude 3 model. If you select a different model (Claude 2.1, Claude 2, or Claude Instant), the `Image` input will not be visible.
+4. Optionally, provide a system prompt to set the context and instructions for Claude.
+5. Execute the node to receive Claude's response based on the provided image, text prompt, and system prompt.
+Note that the `Image` and `System` inputs are only available when using a Claude 3 model. If you select a different model (Claude 2.1, Claude 2, or Claude Instant), these inputs will not be visible.

--- a/packages/docs/docs/user-guide/plugins/built-in/anthropic.md
+++ b/packages/docs/docs/user-guide/plugins/built-in/anthropic.md
@@ -30,6 +30,7 @@ The Chat (Anthropic) node allows you to use the Claude API to generate text.
 | Title  | Data Type                                                    | Description                                       | Default Value | Notes                                                                                                                                                      |
 | ------ | ------------------------------------------------------------ | ------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Prompt | `string` or `string[]` or `chat-message` or `chat-message[]` | The messages to send to Claude to get a response. | (Required)    | Claude does not support a system prompt like GPT does, so you may have to get inventive to place words into Claude's mouth using Prompt nodes set to `AI`. |
+| Image | `image` | An image to send to Claude for analysis. | (Optional) | This input is only available when using a Claude 3 model (Claude 3 Opus or Claude 3 Sonnet). |
 
 #### Outputs
 
@@ -47,3 +48,12 @@ The Chat (Anthropic) node allows you to use the Claude API to generate text.
 | Use Top P   | Whether to use the Top P sampling mode.                                                                                | false          | Yes              | `boolean`       |
 | Max Tokens  | The maximum number of tokens that GPT is allowed to return. When hitting the max tokens, the response will be cut off. | 1024           | Yes              | `number`        |
 | Stop        | Comma separated list of stop tokens. If any stop token is encountered, the response will end immediately.              | (None)         | Yes              | `string[]`      |
+
+#### Using Vision with Claude 3 Models
+When using a Claude 3 model (Claude 3 Opus or Claude 3 Sonnet), an additional `Image` input becomes available in the Chat (Anthropic) node. This input allows you to send an image to Claude for analysis alongside the text prompt.
+To use Vision with Claude 3 models:
+1. Select a Claude 3 model (Claude 3 Opus or Claude 3 Sonnet) in the node settings.
+2. Connect an image to the `Image` input of the Chat (Anthropic) node.
+3. Provide a text prompt that instructs Claude on how to analyze the image.
+4. Execute the node to receive Claude's response based on the provided image and text prompt.
+Note that the `Image` input is only available when using a Claude 3 model. If you select a different model (Claude 2.1, Claude 2, or Claude Instant), the `Image` input will not be visible.

--- a/packages/docs/docs/user-guide/plugins/built-in/anthropic.md
+++ b/packages/docs/docs/user-guide/plugins/built-in/anthropic.md
@@ -41,7 +41,7 @@ The Chat (Anthropic) node allows you to use the Claude API to generate text.
 
 | Setting     | Description                                                                                                            | Default Value  | Use Input Toggle | Input Data Type |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------- | -------------- | ---------------- | --------------- |
-| Model       | The Claude model to use for the request (Claude 3 Opus, Claude 3 Sonnet, Claude 2.1, Claude 2 or Claude Instant)       | Claude 3 Sonnet | Yes              | `string`        |
+| Model       | The Claude model to use for the request (Claude 3 Opus, Claude 3 Sonnet, Claude 2.1, Claude 2 or Claude Instant)       | Claude 2       | Yes              | `string`        |
 | Temperature | The sampling temperature to use. Lower values are more deterministic. Higher values are more "creative".               | 0.5            | Yes              | `number`        |
 | Top P       | Alternate sampling mode using the top X% of values. 0.1 corresponds to the top 10%.                                    | 1              | Yes              | `number`        |
 | Use Top P   | Whether to use the Top P sampling mode.                                                                                | false          | Yes              | `boolean`       |

--- a/packages/docs/docs/user-guide/plugins/built-in/anthropic.md
+++ b/packages/docs/docs/user-guide/plugins/built-in/anthropic.md
@@ -39,11 +39,11 @@ The Chat (Anthropic) node allows you to use the Claude API to generate text.
 
 #### Editor Settings
 
-| Setting     | Description                                                                                                            | Default Value | Use Input Toggle | Input Data Type |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------- | ------------- | ---------------- | --------------- |
-| Model       | The Claude model to use for the request (either Claude 2 or Claude Instant)                                            | Claude 2      | Yes              | `string`        |
-| Temperature | The sampling temperature to use. Lower values are more deterministic. Higher values are more "creative".               | 0.5           | Yes              | `number`        |
-| Top P       | Alternate sampling mode using the top X% of values. 0.1 corresponds to the top 10%.                                    | 1             | Yes              | `number`        |
-| Use Top P   | Whether to use the Top P sampling mode.                                                                                | false         | Yes              | `boolean`       |
-| Max Tokens  | The maximum number of tokens that GPT is allowed to return. When hitting the max tokens, the response will be cut off. | 1024          | Yes              | `number`        |
-| Stop        | Comma separated list of stop tokens. If any stop token is encountered, the response will end immediately.              | (None)        | Yes              | `string[]`      |
+| Setting     | Description                                                                                                            | Default Value  | Use Input Toggle | Input Data Type |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------- | -------------- | ---------------- | --------------- |
+| Model       | The Claude model to use for the request (Claude 3 Opus, Claude 3 Sonnet, Claude 2.1, Claude 2 or Claude Instant)       | Claude 3 Sonnet | Yes              | `string`        |
+| Temperature | The sampling temperature to use. Lower values are more deterministic. Higher values are more "creative".               | 0.5            | Yes              | `number`        |
+| Top P       | Alternate sampling mode using the top X% of values. 0.1 corresponds to the top 10%.                                    | 1              | Yes              | `number`        |
+| Use Top P   | Whether to use the Top P sampling mode.                                                                                | false          | Yes              | `boolean`       |
+| Max Tokens  | The maximum number of tokens that GPT is allowed to return. When hitting the max tokens, the response will be cut off. | 1024           | Yes              | `number`        |
+| Stop        | Comma separated list of stop tokens. If any stop token is encountered, the response will end immediately.              | (None)         | Yes              | `string[]`      |

--- a/packages/docs/docs/user-guide/plugins/built-in/anthropic.md
+++ b/packages/docs/docs/user-guide/plugins/built-in/anthropic.md
@@ -30,8 +30,7 @@ The Chat (Anthropic) node allows you to use the Claude API to generate text.
 | Title  | Data Type                                                    | Description                                       | Default Value | Notes                                                                                                                                                      |
 | ------ | ------------------------------------------------------------ | ------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Prompt | `string` or `string[]` or `chat-message` or `chat-message[]` | The messages to send to Claude to get a response. | (Required)    | Claude Instant and Claude 2.0 does not support a system prompt like GPT does, so you may have to get inventive to place words into Claude's mouth using Prompt nodes set to `AI`. |
-| Image | `image` | An image to send to Claude for analysis. | (Optional) | This input is only available when using a Claude 3 model (Claude 3 Opus or Claude 3 Sonnet). |
-| System  | `string`                                                     | A system prompt to provide context and instructions to Claude. This input is only available when using a Claude 3 model.    | (Optional)    | Use the system prompt to specify a particular goal or role for Claude. See the [guide to system prompts](https://docs.anthropic.com) for more information.  |
+| System  | `string`                                                     | A system prompt to provide context and instructions to Claude. This input is only available when using a Claude 3 model.    | (Optional)    | Use the system prompt to specify a particular goal or role for Claude. You can instead include a `system`-type `chat-message` in the Prompt input. If there are multiple `system`-type messages, only the first one will be used. See the [guide to system prompts](https://docs.anthropic.com) for more information.  |
 
 #### Outputs
 
@@ -51,11 +50,5 @@ The Chat (Anthropic) node allows you to use the Claude API to generate text.
 | Stop        | Comma separated list of stop tokens. If any stop token is encountered, the response will end immediately.              | (None)         | Yes              | `string[]`      |
 
 #### Using Vision with Claude 3 Models
-When using a Claude 3 model (Claude 3 Opus or Claude 3 Sonnet), an additional `Image` input becomes available in the Chat (Anthropic) node. This input allows you to send an image to Claude for analysis alongside the text prompt.
-To use Vision with Claude 3 models:
-1. Select a Claude 3 model (Claude 3 Opus or Claude 3 Sonnet) in the node settings.
-2. Connect an image to the `Image` input of the Chat (Anthropic) node.
-3. Provide a text prompt that instructs Claude on how to analyze the image.
-4. Optionally, provide a system prompt to set the context and instructions for Claude.
-5. Execute the node to receive Claude's response based on the provided image, text prompt, and system prompt.
-Note that the `Image` and `System` inputs are only available when using a Claude 3 model. If you select a different model (Claude 2.1, Claude 2, or Claude Instant), these inputs will not be visible.
+
+When using a Claude 3 model (Claude 3 Opus or Claude 3 Sonnet), you can use the ![Assemble Message Node](../../../node-reference/assemble-message.mdx) to create prompt messages that contain an image.


### PR DESCRIPTION
* Adds Claude 3 models (Sonnet, Opus, Haiku)
* Uses Anthropic's Messages API for Claude 3 models.
* Adds Claude Vision support via images in messages.
* Updates anthropic.md documentation.

Also: makes it a BIT easier to develop on the node-executor

This was originally PR #369, but I don't have permissions on @wayne-chang's fork.