### PR TITLE
fixes LUNA-218 add path to tauri project metadata

### DIFF
--- a/packages/app/src/hooks/useSaveProject.ts
+++ b/packages/app/src/hooks/useSaveProject.ts
@@ -30,18 +30,23 @@ export function useSaveProject() {
       saving = toast.info('Saving project');
     }, 500);
 
-    await ioProvider.saveProjectDataNoPrompt(newProject, { testSuites }, loadedProject.path);
+    try {
+      await ioProvider.saveProjectDataNoPrompt(newProject, { testSuites }, loadedProject.path);
 
-    if (saving != null) {
-      toast.dismiss(saving);
+      if (saving != null) {
+        toast.dismiss(saving);
+      }
+      clearTimeout(savingTimeout);
+
+      toast.success('Project saved');
+      setLoadedProject({
+        loaded: true,
+        path: loadedProject.path,
+      });
+    } catch (cause) {
+      clearTimeout(savingTimeout);
+      toast.error('Failed to save project');
     }
-    clearTimeout(savingTimeout);
-
-    toast.success('Project saved');
-    setLoadedProject({
-      loaded: true,
-      path: loadedProject.path,
-    });
   }
 
   async function saveProjectAs() {
@@ -57,26 +62,31 @@ export function useSaveProject() {
       saving = toast.info('Saving project');
     }, 500);
 
-    const filePath = await ioProvider.saveProjectData(newProject, { testSuites });
+    try {
+      const filePath = await ioProvider.saveProjectData(newProject, { testSuites });
 
-    if (saving != null) {
-      toast.dismiss(saving);
-    }
-    clearTimeout(savingTimeout);
+      if (saving != null) {
+        toast.dismiss(saving);
+      }
+      clearTimeout(savingTimeout);
 
-    if (filePath) {
-      toast.success('Project saved');
-      setLoadedProject({
-        loaded: true,
-        path: filePath,
-      });
-      setOpenedProjects((projects) => ({
-        ...projects,
-        [project.metadata.id]: {
-          project,
-          fsPath: filePath,
-        },
-      }));
+      if (filePath) {
+        toast.success('Project saved');
+        setLoadedProject({
+          loaded: true,
+          path: filePath,
+        });
+        setOpenedProjects((projects) => ({
+          ...projects,
+          [project.metadata.id]: {
+            project,
+            fsPath: filePath,
+          },
+        }));
+      }
+    } catch (cause) {
+      clearTimeout(savingTimeout);
+      toast.error('Failed to save project');
     }
   }
 

--- a/packages/app/src/io/TauriIOProvider.ts
+++ b/packages/app/src/io/TauriIOProvider.ts
@@ -132,7 +132,7 @@ export class TauriIOProvider implements IOProvider {
 
   async loadProjectDataNoPrompt(path: string): Promise<{ project: Project; testData: TrivetData }> {
     const data = await readTextFile(path);
-    const [projectData, attachedData] = deserializeProject(data);
+    const [projectData, attachedData] = deserializeProject(data, path);
 
     const trivetData = attachedData.trivet
       ? deserializeTrivetData(attachedData.trivet as SerializedTrivetData)

--- a/packages/core/src/model/Project.ts
+++ b/packages/core/src/model/Project.ts
@@ -12,6 +12,7 @@ export type Project = {
     title: string;
     description: string;
     mainGraphId?: GraphId;
+    path?: string;
   };
 
   plugins?: PluginLoadSpec[];

--- a/packages/core/src/utils/serialization/serialization.ts
+++ b/packages/core/src/utils/serialization/serialization.ts
@@ -19,9 +19,12 @@ export function serializeProject(project: Project, attachedData?: AttachedData):
   return projectV4Serializer(project, attachedData);
 }
 
-export function deserializeProject(serializedProject: unknown): [Project, AttachedData] {
+export function deserializeProject(serializedProject: unknown, path: string | null = null): [Project, AttachedData] {
   try {
-    return projectV4Deserializer(serializedProject);
+    const result = projectV4Deserializer(serializedProject);
+    if (path !== null)
+      result[0].metadata.path = path;
+    return result;
   } catch (err) {
     if (err instanceof yaml.YAMLError) {
       yamlProblem(err);

--- a/packages/core/src/utils/serialization/serialization_v4.ts
+++ b/packages/core/src/utils/serialization/serialization_v4.ts
@@ -99,7 +99,7 @@ export function projectV4Serializer(project: Project, attachedData?: AttachedDat
   delete filteredProject.metadata.path;
 
   // Make sure all data is ordered deterministically first
-  const stabilized = JSON.parse(stableStringify(toSerializedProject(project, attachedData)));
+  const stabilized = JSON.parse(stableStringify(toSerializedProject(filteredProject, attachedData)));
 
   const serialized = yaml.stringify(
     {

--- a/packages/core/src/utils/serialization/serialization_v4.ts
+++ b/packages/core/src/utils/serialization/serialization_v4.ts
@@ -93,6 +93,11 @@ export function graphV4Deserializer(data: unknown): NodeGraph {
 }
 
 export function projectV4Serializer(project: Project, attachedData?: AttachedData): unknown {
+  const filteredProject = {
+    ...project
+  }
+  delete filteredProject.metadata.path;
+
   // Make sure all data is ordered deterministically first
   const stabilized = JSON.parse(stableStringify(toSerializedProject(project, attachedData)));
 

--- a/packages/core/src/utils/serialization/serialization_v4.ts
+++ b/packages/core/src/utils/serialization/serialization_v4.ts
@@ -94,9 +94,12 @@ export function graphV4Deserializer(data: unknown): NodeGraph {
 
 export function projectV4Serializer(project: Project, attachedData?: AttachedData): unknown {
   const filteredProject = {
-    ...project
+    ...project,
+    metadata: {
+      ...project.metadata,
+      path: undefined,
+    }
   }
-  delete filteredProject.metadata.path;
 
   // Make sure all data is ordered deterministically first
   const stabilized = JSON.parse(stableStringify(toSerializedProject(filteredProject, attachedData)));

--- a/packages/core/test/testUtils.ts
+++ b/packages/core/test/testUtils.ts
@@ -22,11 +22,11 @@ export async function loadTestGraphInProcessor(graphName: string) {
 
 export async function loadProjectFromFile(path: string): Promise<Project> {
   const content = await readFile(path, { encoding: 'utf8' });
-  return loadProjectFromString(content);
+  return loadProjectFromString(content, path);
 }
 
-export function loadProjectFromString(content: string): Project {
-  const [project] = deserializeProject(content);
+export function loadProjectFromString(content: string, path: string | null = null): Project {
+  const [project] = deserializeProject(content, path);
   return project;
 }
 


### PR DESCRIPTION
## What was done
This PR adds path to project metadata as optional variable.  It only loads path in tauri v4 loader.

## Purpose
This will allow us to use the path to automatically output files via the File Node.  For example a usecase would be to automatically export datasets into csv files in the same project folder.  

> Should be a non breaking change to browser loaders and any other project loaders

https://discord.com/channels/1149376303070466110/1149382713904746597/1216788570677837834