### PR TITLE
Openai: add latest gpt4 turbo model

### DIFF
--- a/packages/core/src/plugins/openai/nodes/CreateAssistantNode.ts
+++ b/packages/core/src/plugins/openai/nodes/CreateAssistantNode.ts
@@ -213,7 +213,7 @@ export const CreateAssistantNodeImpl: PluginNodeImpl<CreateAssistantNode> = {
         useInputToggleDataKey: 'useModelInput',
         label: 'Model',
         options: openAiModelOptions,
-        defaultValue: 'gpt-4-1106-preview',
+        defaultValue: 'gpt-4-turbo',
       },
       {
         type: 'string',

--- a/packages/core/src/utils/openai.ts
+++ b/packages/core/src/utils/openai.ts
@@ -116,7 +116,15 @@ export const openaiModels = {
       prompt: 0.01,
       completion: 0.03,
     },
-    displayName: 'GPT-4 Turbo 128K',
+    displayName: 'GPT-4 Turbo 128K (1106 Preview)',
+  },
+  'gpt-4-turbo': {
+    maxTokens: 128000,
+    cost: {
+      prompt: 0.01,
+      completion: 0.03,
+    },
+    displayName: 'GPT-4 Turbo 128K with Vision',
   },
   'gpt-4-vision-preview': {
     maxTokens: 128000,
@@ -124,7 +132,7 @@ export const openaiModels = {
       prompt: 0.01,
       completion: 0.03,
     },
-    displayName: 'GPT-4 Vision',
+    displayName: 'GPT-4 Vision (Preview)',
   },
   'local-model': {
     maxTokens: Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
# Description

Add the new `gpt-4-turbo` model for OpenAI node.

## Context

OpenAI officially released the `gpt-4-turbo` model.

This model is a pointer on the latest turbo version (now it's `gpt-4-turbo-2024-04-09`)

Also, this model include Vision capabilities.

Pricing is the same.

See https://platform.openai.com/docs/models/continuous-model-upgrades