### PR TITLE
feat: add `binary` output port on `HttpCallNode`

### DIFF
--- a/packages/app/src/components/RenderDataValue.tsx
+++ b/packages/app/src/components/RenderDataValue.tsx
@@ -205,7 +205,14 @@ const scalarRenderers: {
       </div>
     );
   },
-  binary: ({ value }) => <>Binary (length {value.value.length.toLocaleString()})</>,
+  binary: ({ value }) => {
+    // FIXME: Coercing `value.value` into a `Uint8Array` here because `Uint8Array` gets parsed as an
+    //        object of shape `{ [index: number]: number }` when stringified via `JSON.stringify()`.
+    //        Consider coercing it back to `Uint8Array` at the entrypoints of the boundaries between
+    //        browser and node.js instead.
+    const coercedValue = new Uint8Array(Object.values(value.value));
+    return <>Binary (length {coercedValue.length.toLocaleString()})</>;
+  },
   audio: ({ value }) => {
     const {
       value: { data },

--- a/packages/core/src/model/nodes/HttpCallNode.ts
+++ b/packages/core/src/model/nodes/HttpCallNode.ts
@@ -249,15 +249,16 @@ export class HttpCallNodeImpl extends NodeImpl<HttpCallNode> {
         },
       };
 
-      const responseBody = await response.text();
+      const responseBlob = await response.blob();
+      const responseText = await responseBlob.text();
 
       output['res_body' as PortId] = {
         type: 'string',
-        value: responseBody,
+        value: responseText,
       };
 
       if (response.headers.get('content-type')?.includes('application/json')) {
-        const jsonData = JSON.parse(responseBody);
+        const jsonData = JSON.parse(responseText);
         output['json' as PortId] = {
           type: 'object',
           value: jsonData,
@@ -268,6 +269,11 @@ export class HttpCallNodeImpl extends NodeImpl<HttpCallNode> {
           value: undefined,
         };
       }
+
+      output['binary' as PortId] = {
+        type: 'binary',
+        value: new Uint8Array(await responseBlob.arrayBuffer()),
+      };
 
       return output;
     } catch (err) {

--- a/packages/core/src/model/nodes/HttpCallNode.ts
+++ b/packages/core/src/model/nodes/HttpCallNode.ts
@@ -105,6 +105,11 @@ export class HttpCallNodeImpl extends NodeImpl<HttpCallNode> {
         title: 'JSON',
       },
       {
+        dataType: 'binary',
+        id: 'binary' as PortId,
+        title: 'Binary',
+      },
+      {
         dataType: 'number',
         id: 'statusCode' as PortId,
         title: 'Status Code',

--- a/packages/core/src/model/nodes/HttpCallNode.ts
+++ b/packages/core/src/model/nodes/HttpCallNode.ts
@@ -28,6 +28,8 @@ export type HttpCallNodeData = {
   body: string;
   useBodyInput?: boolean;
 
+  isBinaryOutput?: boolean;
+
   errorOnNon200?: boolean;
 };
 
@@ -93,22 +95,29 @@ export class HttpCallNodeImpl extends NodeImpl<HttpCallNode> {
   }
 
   getOutputDefinitions(): NodeOutputDefinition[] {
-    return [
-      {
-        dataType: 'string',
-        id: 'res_body' as PortId,
-        title: 'Body',
-      },
-      {
-        dataType: 'object',
-        id: 'json' as PortId,
-        title: 'JSON',
-      },
-      {
+    const outputDefinitions: NodeOutputDefinition[] = [];
+    if (this.data.isBinaryOutput) {
+      outputDefinitions.push({
         dataType: 'binary',
         id: 'binary' as PortId,
         title: 'Binary',
-      },
+      });
+    } else {
+      outputDefinitions.push(
+        {
+          dataType: 'string',
+          id: 'res_body' as PortId,
+          title: 'Body',
+        },
+        {
+          dataType: 'object',
+          id: 'json' as PortId,
+          title: 'JSON',
+        },
+      );
+    }
+
+    outputDefinitions.push(
       {
         dataType: 'number',
         id: 'statusCode' as PortId,
@@ -119,7 +128,9 @@ export class HttpCallNodeImpl extends NodeImpl<HttpCallNode> {
         id: 'res_headers' as PortId,
         title: 'Headers',
       },
-    ];
+    );
+
+    return outputDefinitions;
   }
 
   getEditors(): EditorDefinition<HttpCallNode>[] {
@@ -155,6 +166,11 @@ export class HttpCallNodeImpl extends NodeImpl<HttpCallNode> {
         dataKey: 'body',
         useInputToggleDataKey: 'useBodyInput',
         language: 'json',
+      },
+      {
+        type: 'toggle',
+        label: 'Whether response body is expected to be a binary',
+        dataKey: 'isBinaryOutput',
       },
       {
         type: 'toggle',
@@ -249,31 +265,31 @@ export class HttpCallNodeImpl extends NodeImpl<HttpCallNode> {
         },
       };
 
-      const responseBlob = await response.blob();
-      const responseText = await responseBlob.text();
-
-      output['res_body' as PortId] = {
-        type: 'string',
-        value: responseText,
-      };
-
-      if (response.headers.get('content-type')?.includes('application/json')) {
-        const jsonData = JSON.parse(responseText);
-        output['json' as PortId] = {
-          type: 'object',
-          value: jsonData,
+      if (this.data.isBinaryOutput) {
+        const responseBlob = await response.blob();
+        output['binary' as PortId] = {
+          type: 'binary',
+          value: new Uint8Array(await responseBlob.arrayBuffer()),
         };
       } else {
-        output['json' as PortId] = {
-          type: 'control-flow-excluded',
-          value: undefined,
+        const responseText = await response.text();
+        output['res_body' as PortId] = {
+          type: 'string',
+          value: responseText,
         };
+        if (response.headers.get('content-type')?.includes('application/json')) {
+          const jsonData = JSON.parse(responseText);
+          output['json' as PortId] = {
+            type: 'object',
+            value: jsonData,
+          };
+        } else {
+          output['json' as PortId] = {
+            type: 'control-flow-excluded',
+            value: undefined,
+          };
+        }
       }
-
-      output['binary' as PortId] = {
-        type: 'binary',
-        value: new Uint8Array(await responseBlob.arrayBuffer()),
-      };
 
       return output;
     } catch (err) {


### PR DESCRIPTION
Resolves #386

### Context

Previously, it wasn't possible to make a HTTP call (via `HttpCallNode`) and have the binary/blob data passed to an `ImageNode`. This PR introduces a new `binary` output port (alongside the existing `body` and `json` output ports) on `HttpCallNode` to make this possible.

### Screengrab

![CleanShot 2024-04-27 at 19 43 25@2x](https://github.com/Ironclad/rivet/assets/3143132/fc032e7d-e95b-4057-81c0-e857794b561e)

### How to test

1. Launch the app with the test Rivet project below
2. Switch executor to Node
3. Run entire graph
4. Observe that fetched image (of my cat 😼) should show up in the `ImageNode`, proving that the feature works

#### Test Rivet project

```
version: 4
data:
  attachedData:
    trivet:
      testSuites: []
      version: 1
  graphs:
    q8Tc5Q-34WB8e-loWqoON:
      metadata:
        description: ""
        id: q8Tc5Q-34WB8e-loWqoON
        name: Untitled Graph
      nodes:
        '[Ux7TlwMXhLmKxUjdiDuIc]:httpCall "Http Call"':
          data:
            body: ""
            errorOnNon200: true
            headers: ""
            method: GET
            url: https://github.com/liaujianjie.png
          outgoingConnections:
            - binary->"Image" owgnZUkpDj7Ik93OtyOGd/data
          visualData: 497/390/280/3//
        '[owgnZUkpDj7Ik93OtyOGd]:image "Image"':
          data:
            mediaType: image/png
            useDataInput: true
            useMediaTypeInput: false
          visualData: 1029/376/484.1567767955994/7//
  metadata:
    description: ""
    id: _A_qCLGKHitAnTSshRby2
    title: Untitled Project
  plugins: []

```