### PR TITLE
OpenAI: add GPT-4o model

### DIFF
--- a/packages/core/src/utils/openai.ts
+++ b/packages/core/src/utils/openai.ts
@@ -134,6 +134,14 @@ export const openaiModels = {
     },
     displayName: 'GPT-4 Vision (Preview)',
   },
+  'gpt-4o': {
+    maxTokens: 128000,
+    cost: {
+      prompt: 0.005,
+      completion: 0.015,
+    },
+    displayName: 'GPT-4o',
+  },
   'local-model': {
     maxTokens: Number.MAX_SAFE_INTEGER,
     cost: {


### PR DESCRIPTION
# Description

Add the new `gpt-4o` model for OpenAI node.

## Context

OpenAI officially released the `gpt-4o` model.

https://platform.openai.com/docs/models/gpt-4o