### PR TITLE
fix(core): some callback listeners missing in coreCreateProcessor

### DIFF
--- a/packages/core/src/api/createProcessor.ts
+++ b/packages/core/src/api/createProcessor.ts
@@ -95,6 +95,18 @@ export function coreCreateProcessor(project: Project, options: RunGraphOptions) 
     processor.on('nodeExcluded', options.onNodeExcluded);
   }
 
+  if (options.onGraphStart) {
+    processor.on('graphStart', options.onGraphStart);
+  }
+
+  if (options.onGraphError) {
+    processor.on('graphError', options.onGraphError);
+  }
+
+  if (options.onGraphFinish) {
+    processor.on('graphFinish', options.onGraphFinish);
+  }
+
   if (options.onPartialOutput) {
     processor.on('partialOutput', options.onPartialOutput);
   }


### PR DESCRIPTION
While I was trying to monitor subgraphs executions in Langfuse, I figured that the callbacks `onGraphStart`, `onGraphEnd` and `onGraphError` specified in my `runGraph` options do not work.

It seems they were forgotten in `coreCreateProcessor`, so I added them.