### PR TITLE
Update AssemblyAI docs

### DIFF
--- a/packages/docs/docs/user-guide/plugins/built-in/assemblyai.md
+++ b/packages/docs/docs/user-guide/plugins/built-in/assemblyai.md
@@ -4,12 +4,6 @@ sidebar_label: AssemblyAI
 
 # AssemblyAI Plugin
 
-:::info
-
-At the moment you must use the [node executor](../../executors.md) to use the AssemblyAI plugin in the Rivet UI. You may also use the plugin when embedding Rivet in your own application.
-
-:::
-
 ## Nodes
 
 ### Transcribe Audio Node
@@ -22,7 +16,7 @@ The Transcribe Audio node transcribes audio using the [AssemblyAI](https://www.a
 
 AssemblyAI's LeMUR (Leveraging Large Language Models to Understand Recognized Speech) is a framework to process audio files with an LLM.
 The AssemblyAI plugin has a dedicated node for each LeMUR endpoint.
-Each node accepts Transcript IDs as input which you can get from the Transcribe Audio Node. Additional parameters are available as inputs and as node configuration. For more information what these parameters do, [check out the LeMUR API reference](https://www.assemblyai.com/docs/api-reference/lemur?utm_source=lemur).
+Each node accepts Transcript IDs or Input Text as input which you can get from the Transcribe Audio Node. Additional parameters are available as inputs and as node configuration. For more information what these parameters do, [check out the LeMUR API reference](https://www.assemblyai.com/docs/api-reference/lemur?utm_source=lemur).
 
 #### LeMUR Summary Node
 


### PR DESCRIPTION
The LeMUR API now supports CORS requests, so the LeMUR nodes no longer require using the Node executor.
Also added that you can provide Input Text as well instead of Transcript IDs.