### PR TITLE
Bind subgraph newAbortController event to parent graph

### DIFF
--- a/packages/core/src/model/GraphProcessor.ts
+++ b/packages/core/src/model/GraphProcessor.ts
@@ -1513,6 +1513,7 @@ export class GraphProcessor {
         processor.on('graphStart', (e) => this.#emitter.emit('graphStart', e));
         processor.on('graphFinish', (e) => this.#emitter.emit('graphFinish', e));
         processor.on('globalSet', (e) => this.#emitter.emit('globalSet', e));
+        processor.on('newAbortController', (e) => this.#emitter.emit('newAbortController', e));
         processor.on('pause', () => {
           if (!this.#isPaused) {
             this.pause();


### PR DESCRIPTION
Using `--trace-warnings` I think the warning is still happening because of subgraphs - the event is only bound in `createProcessor`, but the trace shows the call stack going through `SubGraphNodeImpl` and `createSubProcessor` does not bind this event so the controllers aren't passed back up. 

