### PR TITLE
Remove listener limits on abort controllers

### DIFF
--- a/packages/node/src/api.ts
+++ b/packages/node/src/api.ts
@@ -46,7 +46,7 @@ export function createProcessor(
   processor.processor.executor = 'nodejs';
 
   processor.processor.on('newAbortController', (controller) => {
-    events.setMaxListeners(100, controller.signal);
+    events.setMaxListeners(0, controller.signal);
   });
 
   if (options.remoteDebugger) {


### PR DESCRIPTION
Still seeing this warning in production. I think since we determined this not a memory, I think it's better to disable the warning outright rather than set it to an arbitrarily high number 