### PR TITLE
Add parameter for parallel tool calls

### DIFF
--- a/packages/core/src/model/nodes/ChatNodeBase.ts
+++ b/packages/core/src/model/nodes/ChatNodeBase.ts
@@ -850,6 +850,7 @@ export const ChatNodeBase = {
     const seed = getInputOrData(data, inputs, 'seed', 'number');
     const responseFormat = getInputOrData(data, inputs, 'responseFormat') as 'text' | 'json' | 'json_schema' | '';
     const toolChoiceMode = getInputOrData(data, inputs, 'toolChoice', 'string') as 'none' | 'auto' | 'function';
+    const parallelFunctionCalling = getInputOrData(data, inputs, 'parallelFunctionCalling', 'boolean');
 
     const predictedOutput = data.usePredictedOutput
       ? coerceTypeOptional(inputs['predictedOutput' as PortId], 'string[]')
@@ -1054,6 +1055,7 @@ export const ChatNodeBase = {
             seed,
             response_format: openaiResponseFormat,
             tool_choice: toolChoice,
+            parallel_tool_calls: parallelFunctionCalling,
             prediction: predictionObject,
             modalities,
             audio,

--- a/packages/core/src/utils/openai.ts
+++ b/packages/core/src/utils/openai.ts
@@ -311,6 +311,7 @@ export type ChatCompletionOptions = {
           name: string;
         };
       };
+  parallel_tool_calls?: boolean;
 
   /** An object specifying the format that the model must output. Used to enable JSON mode. */
   response_format?:


### PR DESCRIPTION
- OpenAI updated their API to use `parallel_tool_calls` and its on by default
- This change connects the existing `parallelFunctionCalling` state to the new parameter which is an optional parameter in the updated API