### PR TITLE
feat: adds custom settings page for plugins

### DIFF
--- a/packages/app/src/components/SettingsModal.tsx
+++ b/packages/app/src/components/SettingsModal.tsx
@@ -123,7 +123,7 @@ export const SettingsModal: FC<SettingsModalProps> = () => {
                         OpenAI
                       </ButtonItem>
                       <ButtonItem isSelected={page === 'plugins'} onClick={() => setPage('plugins')}>
-                        Plugins here
+                        Plugins
                       </ButtonItem>
                       <ButtonItem isSelected={page === 'updates'} onClick={() => setPage('updates')}>
                         Updates

--- a/packages/core/src/model/RivetPlugin.ts
+++ b/packages/core/src/model/RivetPlugin.ts
@@ -26,6 +26,7 @@ export type RivetPlugin = {
 export type RivetPluginConfigSpecs = Record<string, PluginConfigurationSpec>;
 
 export type RivetPluginConfigPage = {
+  id: string;
   label: string;
   description?: string;
 };

--- a/packages/core/src/model/RivetPlugin.ts
+++ b/packages/core/src/model/RivetPlugin.ts
@@ -14,6 +14,8 @@ export type RivetPlugin = {
   /** The available configuration items and their specification, for configuring a plugin in the UI. */
   configSpec?: RivetPluginConfigSpecs;
 
+  configPage?: RivetPluginConfigPage;
+
   /** Defines additional context menu groups that the plugin adds. */
   contextMenuGroups?: Array<{
     id: string;
@@ -22,6 +24,11 @@ export type RivetPlugin = {
 };
 
 export type RivetPluginConfigSpecs = Record<string, PluginConfigurationSpec>;
+
+export type RivetPluginConfigPage = {
+  label: string;
+  description?: string;
+};
 
 export type PluginConfigurationSpecBase<T> = {
   /** The type of the config value, how it should show as an editor in the UI. */


### PR DESCRIPTION
# Context

Adds option to set plugin configuration as a new tab in Settings Modal.


Ex:

<img width="405" alt="image" src="https://github.com/user-attachments/assets/e6b5a9ab-9686-4b68-8639-0660c3cd18fa" />

