### PR TITLE
Improve error formatting

### DIFF
--- a/packages/core/src/model/GraphProcessor.ts
+++ b/packages/core/src/model/GraphProcessor.ts
@@ -23,7 +23,8 @@ import type { GraphId, NodeGraph } from './NodeGraph.js';
 import type { NodeImpl } from './NodeImpl.js';
 import type { UserInputNode } from './nodes/UserInputNode.js';
 import PQueueImport from 'p-queue';
-import { getError, NodeError } from '../utils/errors.js';
+import { getError } from '../utils/errors.js';
+import type { NodeError } from '../utils/errors.js';
 import Emittery from 'emittery';
 import { entries, fromEntries, values } from '../utils/typeSafety.js';
 import { isNotNull } from '../utils/genericUtilFunctions.js';
@@ -1440,10 +1441,11 @@ export class GraphProcessor {
 
   #nodeErrored(node: ChartNode, e: unknown, processId: ProcessId) {
     const error = getError(e);
+    (error as NodeError).node = node;
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.#emitter.emit('nodeError', { node, error, processId });
     this.#emitTraceEvent(`Node ${node.title} (${node.id}-${processId}) errored: ${error.stack}`);
-    this.#erroredNodes.set(node.id, new NodeError(error.message, node, { cause: error }));
+    this.#erroredNodes.set(node.id, error);
   }
 
   getRootProcessor(): GraphProcessor {

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -1,13 +1,11 @@
 import type { ChartNode } from '../model/NodeBase.js';
 
-export class NodeError extends Error {
-  constructor(
-    message: string,
-    public readonly node: ChartNode,
-    options?: ErrorOptions,
-  ) {
-    super(message, options);
-  }
+export interface NodeError extends Error {
+  node: ChartNode;
+}
+
+export function isNodeError(error: Error): error is NodeError {
+  return 'node' in error && typeof (error.node as ChartNode)?.id === 'string';
 }
 
 /** Gets an Error from an unknown error object (strict unknown errors is enabled, helper util). */
@@ -33,7 +31,7 @@ export function rivetErrorToString(error: unknown, spaces = 0): string {
   }
 
   let message = error.message;
-  if (error instanceof NodeError) {
+  if (isNodeError(error)) {
     const { node } = error;
     message = `${node.title} (${node.id}): ${error.message}`;
   }

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -1,3 +1,15 @@
+import type { ChartNode } from '../model/NodeBase.js';
+
+export class NodeError extends Error {
+  constructor(
+    message: string,
+    public readonly node: ChartNode,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+  }
+}
+
 /** Gets an Error from an unknown error object (strict unknown errors is enabled, helper util). */
 export function getError(error: unknown): Error {
   const errorInstance =
@@ -5,4 +17,38 @@ export function getError(error: unknown): Error {
       ? error
       : new Error(error != null ? error.toString() : 'Unknown error');
   return errorInstance;
+}
+
+export function rivetErrorToString(error: unknown, spaces = 0): string {
+  if (!(error instanceof Error)) {
+    if (error == null) {
+      return 'Unknown error';
+    }
+
+    return String(error);
+  }
+
+  if (error instanceof AggregateError) {
+    return error.message + '\n' + error.errors.map((e) => ' - ' + rivetErrorToString(e, spaces + 4)).join('\n');
+  }
+
+  let message = error.message;
+  if (error instanceof NodeError) {
+    const { node } = error;
+    message = `${node.title} (${node.id}): ${error.message}`;
+  }
+
+  if (error.cause) {
+    message += `\nCaused by: ${rivetErrorToString(error.cause)}`;
+  }
+
+  return indent(message, spaces);
+}
+
+function indent(str: string, spaces: number): string {
+  const spacing = ' '.repeat(spaces);
+  return str
+    .split('\n')
+    .map((line, i) => (i === 0 ? line : spacing + line))
+    .join('\n');
 }

--- a/packages/core/test/utils/errors.test.ts
+++ b/packages/core/test/utils/errors.test.ts
@@ -1,0 +1,37 @@
+import { it, describe } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { type NodeId } from '../../src/index.js';
+import { NodeError, rivetErrorToString } from '../../src/utils/errors.js';
+
+describe('rivetErrorToString', () => {
+  it('should handle AggregateError', () => {
+    assert.equal(
+      rivetErrorToString(
+        new AggregateError(
+          [
+            new Error('Error 1', { cause: new Error('Root cause') }),
+            new NodeError('Error 2', {
+              data: undefined,
+              id: 'nodeId' as NodeId,
+              title: 'Node title',
+              type: 'type',
+              visualData: {} as any, // Unused
+            }),
+            'Error 3',
+            null,
+          ],
+          'Multiple errors',
+        ),
+      ),
+      `
+Multiple errors
+ - Error 1
+    Caused by: Root cause
+ - Node title (nodeId): Error 2
+ - Error 3
+ - Unknown error
+      `.trim(),
+    );
+  });
+});

--- a/packages/core/test/utils/errors.test.ts
+++ b/packages/core/test/utils/errors.test.ts
@@ -6,18 +6,21 @@ import { NodeError, rivetErrorToString } from '../../src/utils/errors.js';
 
 describe('rivetErrorToString', () => {
   it('should handle AggregateError', () => {
+    const nodeError = new Error('Error 2');
+    (nodeError as NodeError).node = {
+      data: undefined,
+      id: 'nodeId' as NodeId,
+      title: 'Node title',
+      type: 'type',
+      visualData: {} as any, // Unused
+    };
+
     assert.equal(
       rivetErrorToString(
         new AggregateError(
           [
-            new Error('Error 1', { cause: new Error('Root cause') }),
-            new NodeError('Error 2', {
-              data: undefined,
-              id: 'nodeId' as NodeId,
-              title: 'Node title',
-              type: 'type',
-              visualData: {} as any, // Unused
-            }),
+            new Error('Error 1', { cause: new Error('Root cause') }), //
+            nodeError,
             'Error 3',
             null,
           ],


### PR DESCRIPTION
Add new error formatter for prettifying errors emitted from Rivet. To do this I've attached the ChartNode object to the Error itself - it's not great but I think this is the best way to propagate node info to the formatter without having to add another wrapping Error class 