### PR TITLE
Changed how "Split" nodes look for better visibility

### DIFF
--- a/packages/app/src/components/VisualNode.tsx
+++ b/packages/app/src/components/VisualNode.tsx
@@ -232,6 +232,7 @@ export const VisualNode = memo(
               zoomedOut: isZoomedOut,
               isComment,
               isPinned,
+              isSplit: node.isSplitRun,
               disabled: node.disabled,
               conditional: !!node.isConditional,
             },

--- a/packages/app/src/components/nodeStyles.ts
+++ b/packages/app/src/components/nodeStyles.ts
@@ -85,6 +85,24 @@ export const nodeStyles = css`
     padding-left: 30px;
   }
 
+  .node.isSplit .node-title .grab-area svg {
+    transform: rotate(90deg);
+  }
+
+  .node.isSplit::before {
+    content: "";
+    position: absolute;
+    top: -12px;
+    left: 10px;
+    width: 100%;
+    height: 100%;
+    border: 2px solid var(--node-border);
+    border-radius: inherit;
+    clip-path: polygon(0 0, 100% 0, 100% 100%, calc(100% - 12px) 100%, calc(100% - 12px) 10px, 0 10px);
+    -webkit-mask-image: linear-gradient(to bottom, black 0%, black calc(100% - 71px), transparent calc(100% - 30px));
+  }
+
+
   .node.node.isComment .node-title {
     padding: 4px;
     background-color: var(--grey-darkish-seethrough);
@@ -179,6 +197,8 @@ export const nodeStyles = css`
   .node.isPinned .title-controls .pin-button {
     color: var(--primary-text);
   }
+
+
 
   .title-controls .tooltip {
     display: flex;


### PR DESCRIPTION
I believe the current icon for "Split node" indication is too subtle and barely helps to spot "Split" nodes. 

So I did two things:
- Added a more prominent "stack effect" to "Split" nodes. It's supposed to illustrate that the node is expected to run multiple times.
- Turned the split icon (in the node header) 90 degrees so it alings with the Rivet's natural left-to-right flow.

![image](https://github.com/user-attachments/assets/5a375f59-179e-4155-bfcd-c758999d1d15)
