### PR TITLE
Fix two typos on RunGraphOptions

### DIFF
--- a/packages/docs/docs/api-reference/node/RunGraphOptions.mdx
+++ b/packages/docs/docs/api-reference/node/RunGraphOptions.mdx
@@ -71,7 +71,7 @@ The `externalFunctions` property is an optional object that can be used to provi
 
 A function must return a `Promise` that resolves to a `DataValue` or `undefined`. The `DataValue` returned by the function will be passed to the graph as the result of the function call.
 
-See (DataValue)[../core/DataValue] for more information about the different types of values that can be returned from an external function.
+See [DataValue](../core/DataValue) for more information about the different types of values that can be returned from an external function.
 
 ### onUserEvent
 
@@ -93,7 +93,7 @@ This part of the `RunGraphOptions` type represents an object of event handlers f
 
 ## Settings
 
-The properties of (Settings)[../core/Settings] are merged into the `RunGraphOptions` type. Some properties on Settings are required. See that page for more information.
+The properties of [Settings](../core/Settings) are merged into the `RunGraphOptions` type. Some properties on Settings are required. See that page for more information.
 
 ## See Also
 


### PR DESCRIPTION
Fix two incorrect Markdown hyperlink format on https://rivet.ironcladapp.com/docs/api-reference/node/RunGraphOptions 