### PR TITLE
Update docs for v3 compatibility

### DIFF
--- a/packages/docs/docs/node-reference/compare.mdx
+++ b/packages/docs/docs/node-reference/compare.mdx
@@ -49,7 +49,7 @@ The Compare Node allows you to perform a comparison operation between two input 
 
 | Setting             | Description                                                                                                                       | Default Value | Use Input Toggle | Input Data Type |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------- | ---------------- | --------------- |
-| Comparison Function | The comparison function to be used for the operation. Available options are '==', '<', '>', '<=', '>=', '!=', 'and', 'or', 'xor'. | '=='          | Yes              | `string`        |
+| Comparison Function | The comparison function to be used for the operation. Available options are '==', '&lt;', '>', '&lt;=', '>=', '!=', 'and', 'or', 'xor'. | '=='          | Yes              | `string`        |
 
 </TabItem>
 

--- a/packages/docs/docs/node-reference/gpt-function.mdx
+++ b/packages/docs/docs/node-reference/gpt-function.mdx
@@ -34,7 +34,7 @@ You may use interpolation values in the GPT Function schema the same way you can
 
 | Title   | Data Type | Description                                                                                                   | Default Value  | Notes |
 | ------- | --------- | ------------------------------------------------------------------------------------------------------------- | -------------- | ----- |
-| Input N | `string`  | Variable number of inputs for interpolated values such as {{value}} inside the schema definition of the node. | (empty string) |       |
+| Input N | `string`  | Variable number of inputs for interpolated values such as `{{value}}` inside the schema definition of the node. | (empty string) |       |
 
 </TabItem>
 

--- a/packages/docs/docs/node-reference/replace-dataset.mdx
+++ b/packages/docs/docs/node-reference/replace-dataset.mdx
@@ -32,7 +32,7 @@ For more information on datasets, see the [Data Studio](../user-guide/features/d
 
 | Title      | Data Type  | Description                                                                                                                                                                                                      | Default Value                                               | Notes                                                                        |
 | ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Data       | `object[]` | The new data of the dataset. If empty, the dataset will be cleared. May be an array of array of strings, or an array of DatasetRow objects with { id, data } properties. If a string[][], IDs will be generated. | (empty)                                                     | The input will be coerced into an object array if it is not an object array. |
+| Data       | `object[]` | The new data of the dataset. If empty, the dataset will be cleared. May be an array of array of strings, or an array of DatasetRow objects with `{ id, data }` properties. If a string[][], IDs will be generated. | (empty)                                                     | The input will be coerced into an object array if it is not an object array. |
 | Dataset ID | `string`   | The ID of the dataset to replace. This input is only available if `Use Dataset ID Input` is enabled.                                                                                                             | (required if if the input toggle for Dataset ID is enabled) | The input will be coerced into a string if it is not a string.               |
 
 </TabItem>
@@ -43,7 +43,7 @@ For more information on datasets, see the [Data Studio](../user-guide/features/d
 
 | Title   | Data Type  | Description                                                                               | Notes                                                                               |
 | ------- | ---------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| Dataset | `object[]` | The new data of the dataset. An array of DatasetRow objects with { id, data } properties. | The output will be an object containing the ID, data, and embedding of the new row. |
+| Dataset | `object[]` | The new data of the dataset. An array of DatasetRow objects with `{ id, data }` properties. | The output will be an object containing the ID, data, and embedding of the new row. |
 
 </TabItem>
 

--- a/packages/docs/docs/tutorial/02-interpolation-more-node-types.md
+++ b/packages/docs/docs/tutorial/02-interpolation-more-node-types.md
@@ -46,13 +46,13 @@ The system prompt is connected to the `System Prompt` port of all the [Chat Node
 
 After each of the chats has (in parallel) generated its output (the first being an introduction, and asking the user what contract to generate, and the 2nd being a list of contracts it can generate), the two outputs are fed into a [Text Node](../node-reference/text.mdx) that combines the two outputs into one string:
 
-> {{introduction}}
+> \{\{introduction}}
 >
 > Here are some contract types I can generate templates for:
 >
-> {{templates}}
+> \{\{templates}}
 
-The text inside {{curly_braces}} is marked as a replacement for one of the input ports of the text node. The inputs to the text node are dynamic based on the text prompt inside the text node. In this case, we get two inputs, `introduction` and `templates`, corresponding to the two {{curly_braces}} in the text prompt and the two previous chat nodes.
+The text inside `{{curly_braces}}` is marked as a replacement for one of the input ports of the text node. The inputs to the text node are dynamic based on the text prompt inside the text node. In this case, we get two inputs, `introduction` and `templates`, corresponding to the two `{{curly_braces}}` in the text prompt and the two previous chat nodes.
 
 ## User Input
 
@@ -68,7 +68,7 @@ The next thing we do is combine all these messages together using an [Assemble P
 
 The prompt is a [Prompt Node](../node-reference/prompt.mdx) set to type System with the following text:
 
-> The user has indicated that they want to generate this contract type: {{type}}. You must now output a template for this contract type. Only reply with a template.
+> The user has indicated that they want to generate this contract type: \{\{type}}. You must now output a template for this contract type. Only reply with a template.
 
 We pass the text the user entered for the user input node into the `type` port of the system prompt.
 


### PR DESCRIPTION
Updated doc content for v3 forward compat following these instructions https://docusaurus.io/docs/migration/v3#common-mdx-problems. These should have no visible changes since all these are backwards compatible. 

I also tried to actually run the upgrade and got blocked by a yarn pnp bug which is fun https://github.com/yarnpkg/berry/issues/6580 