### PR TITLE
Fix MCPGetPromptNode prompt response always undefined

### DIFF
--- a/packages/core/src/model/nodes/MCPGetPromptNode.ts
+++ b/packages/core/src/model/nodes/MCPGetPromptNode.ts
@@ -273,7 +273,7 @@ export class MCPGetPromptNodeImpl extends NodeImpl<MCPGetPromptNode> {
 
       const output: Outputs = {};
 
-      output['response' as PortId] = {
+      output['prompt' as PortId] = {
         type: 'object',
         value: getPromptResponse as unknown as Record<string, unknown>,
       };


### PR DESCRIPTION
fix: MCP Get Prompt Node output being always undefined due to wrong output portId when creating prompt response