### PR TITLE
Set React Dev Tools Script Tag in Dev Mode

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig } from 'vite';
+import { defineConfig, splitVendorChunkPlugin } from 'vite';
+import type { PluginOption } from 'vite';
 import react from '@vitejs/plugin-react';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 import svgr from 'vite-plugin-svgr';
@@ -6,7 +7,27 @@ import monacoEditorPlugin from 'vite-plugin-monaco-editor';
 import topLevelAwait from 'vite-plugin-top-level-await';
 import { resolve } from 'node:path';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { splitVendorChunkPlugin } from 'vite';
+
+const reactDevTools = (): PluginOption => {
+  return {
+    name: 'react-devtools',
+    apply: 'serve', // Only apply this plugin during development
+    transformIndexHtml(html) {
+      return {
+        html,
+        tags: [
+          {
+            tag: 'script',
+            attrs: {
+              src: 'http://localhost:8097',
+            },
+            injectTo: 'head',
+          },
+        ],
+      };
+    },
+  };
+};
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -35,6 +56,7 @@ export default defineConfig({
     },
   },
   plugins: [
+    reactDevTools(),
     react(),
     viteTsconfigPaths(),
     svgr({


### PR DESCRIPTION
Adds a plugin to add the necessary local `react-devtools` script tag for the [standalone `react-devtools` app](https://www.npmjs.com/package/react-devtools) to listen to and use during development. Solution found from https://eikowagenknecht.de/posts/using-react-devtools-with-tauri-v2-and-vite/#solution.

I couldn't seem to find anything in the contributing docs about developing with react or similar DOM dev tooling, so apologies if a solution already exists and this is cluttering open PRs!


https://github.com/user-attachments/assets/b9cef04c-2155-4db1-9d07-ff67bf6b3fc4

