### PR TITLE
update example with current models

### DIFF
--- a/examples/rpg/RPG.rivet-project
+++ b/examples/rpg/RPG.rivet-project
@@ -17,7 +17,7 @@ data:
           outgoingConnections:
             - break->"Graph Output" ohWFXJb-hWKitJ04P0UqU/value
             - output1->"Subgraph" A-odjcL20cfB8GhtGE3y1/History
-          visualData: 1859.0504235572942/423.7745123526969/250/261
+          visualData: 1859.0504235572942/423.7745123526969/250/261//
         '[A-odjcL20cfB8GhtGE3y1]:subGraph "Subgraph"':
           data:
             graphId: vTLQi8hE7_JmspagWbMjj
@@ -25,7 +25,7 @@ data:
             useErrorOutput: false
           outgoingConnections:
             - prompt->"Loop Controller" 9Jk66n3uE3eYHtYqOrN1L/input1
-          visualData: 1829.1042059233162/140.69263559637687/300/280
+          visualData: 1829.1042059233162/140.69263559637687/300/280//
         '[c28d8AMDpBadvt0b7k0w2]:subGraph "Subgraph"':
           data:
             graphId: lmIfZ8Xyn2kK_qNvKMA1E
@@ -33,12 +33,12 @@ data:
             useErrorOutput: false
           outgoingConnections:
             - History->"Loop Controller" 9Jk66n3uE3eYHtYqOrN1L/input1Default
-          visualData: 1231.4938302675062/459.3925600153625/300/282
+          visualData: 1231.4938302675062/459.3925600153625/300/282//
         '[ohWFXJb-hWKitJ04P0UqU]:graphOutput "Graph Output"':
           data:
             dataType: string
             id: output
-          visualData: 2357.253020175532/398.1229728984283/300/266
+          visualData: 2357.253020175532/398.1229728984283/300/266//
     lmIfZ8Xyn2kK_qNvKMA1E:
       metadata:
         description: Initialize the chat history by generating an adventure setting and
@@ -59,21 +59,21 @@ data:
             useTypeInput: false
           outgoingConnections:
             - output->"Chat" UL_wjl3ZdjO19v0tgBd0o/prompt
-          visualData: 17.77146026780541/341.17466249615677/250/276
+          visualData: 17.77146026780541/341.17466249615677/250/276//
         '[BbSBg2I_xVzVqYSSv3eaS]:comment "Comment"':
           data:
             backgroundColor: rgba(0,0,0,0.05)
             color: rgba(255,255,255,1)
             height: 1140.575557441464
             text: "## Generate Adventure Setting"
-          visualData: -1084.7527636270468/-134.76476320402628/2733.2737417361914/251
+          visualData: -1084.7527636270468/-134.76476320402628/2733.2737417361914/251//
         '[EkDAi0it6_2K5NpeYIxBg]:extractObjectPath "Extract Object Path"':
           data:
             path: $[{{input}}]
             usePathInput: true
           outgoingConnections:
             - match->"Prompt" -o3d9Tb_NeP4TX6Sj5_Ae/setting
-          visualData: -295.8413275092507/381.04938938155294/250/227
+          visualData: -295.8413275092507/381.04938938155294/250/227//
         '[Gu2eNEDwQnnxFFI9ZHPiZ]:randomNumber "RNG"':
           data:
             integers: true
@@ -82,12 +82,12 @@ data:
             min: 0
           outgoingConnections:
             - value->"Text" Qkh5uJYb2jVSMk42qJpZy/input
-          visualData: -932.0996083124934/608.3258101904802/150/233
+          visualData: -932.0996083124934/608.3258101904802/150/233//
         '[H6sfMx6smlRGfdPb1OB4A]:graphOutput "Graph Output"':
           data:
             dataType: chat-message[]
             id: History
-          visualData: 1864.015972056152/422.6609635754086/300/282
+          visualData: 1864.015972056152/422.6609635754086/300/282//
         '[HxX25H4Vq46HKQHet_g7w]:text "Text"':
           data:
             text: |-
@@ -97,27 +97,29 @@ data:
           outgoingConnections:
             - output->"Prompt" plnkXY2kcKNK3J6rariTg/input
             - output->"User Input" z1jCBTkKd_SqkKzb2ARPI/questions
-          visualData: 643.8512100078477/206.6821598331501/300/283
+          visualData: 643.8512100078477/206.6821598331501/300/283//
         '[KQXczbLkzL_QFjG4fQqKE]:array "Array"':
           data:
             flatten: true
             flattenDeep: false
           outgoingConnections:
             - output->"Extract Object Path" EkDAi0it6_2K5NpeYIxBg/object
-          visualData: -614.7649452454968/263.8405868076044/200/228
+          visualData: -614.7649452454968/263.8405868076044/200/228//
         '[Qkh5uJYb2jVSMk42qJpZy]:text "Text"':
           data:
             text: $[{{input}}]
           outgoingConnections:
             - output->"Extract Object Path" EkDAi0it6_2K5NpeYIxBg/path
-          visualData: -662.8251413753565/595.0104321521977/300/229
+          visualData: -662.8251413753565/595.0104321521977/300/229//
         '[UL_wjl3ZdjO19v0tgBd0o]:chat "Chat"':
           data:
+            additionalParameters: []
             cache: false
             enableFunctionUse: false
             frequencyPenalty: 0
+            headers: []
             maxTokens: 512
-            model: gpt-3.5-turbo-16k-0613
+            model: gpt-4
             presencePenalty: 0
             stop: ""
             temperature: 1
@@ -136,7 +138,7 @@ data:
             useUserInput: false
           outgoingConnections:
             - response->"Text" HxX25H4Vq46HKQHet_g7w/initialSetting
-          visualData: 351.1627070188595/135.9482805940119/200/277
+          visualData: 351.1627070188595/135.9482805940119/200/286//
         '[fRHHNhgHGixly258xsiUN]:prompt "Prompt"':
           data:
             enableFunctionCall: false
@@ -149,7 +151,7 @@ data:
             useTypeInput: false
           outgoingConnections:
             - output->"Chat" UL_wjl3ZdjO19v0tgBd0o/systemPrompt
-          visualData: -191.86112774473116/55.320103509079956/250/244
+          visualData: -191.86112774473116/55.320103509079956/250/244//
         '[plnkXY2kcKNK3J6rariTg]:prompt "Prompt"':
           data:
             enableFunctionCall: false
@@ -158,36 +160,36 @@ data:
             useTypeInput: false
           outgoingConnections:
             - output->"Assemble Prompt" zKRlWy2cdfSjYzaMkiZwJ/message1
-          visualData: 1046.3456835880286/240.97141268849006/250/285
+          visualData: 1046.3456835880286/240.97141268849006/250/285//
         '[qCMcssGyvj9olRUpQe6Xj]:text "Text"':
           data:
             text: World war 2 spy
           outgoingConnections:
             - output->"Array" KQXczbLkzL_QFjG4fQqKE/input3
-          visualData: -1011.894545922826/440.28205117420356/300/226
+          visualData: -1011.894545922826/440.28205117420356/300/226//
         '[xK17MLlthCFEhmmRFuLSD]:text "Text"':
           data:
             text: Sci-fi space colony
           outgoingConnections:
             - output->"Array" KQXczbLkzL_QFjG4fQqKE/input1
-          visualData: -1011.894545922826/132.58588827865657/300/226
+          visualData: -1011.894545922826/132.58588827865657/300/226//
         '[xsw_IUIsD1KdS62_WJyQP]:text "Text"':
           data:
             text: Fantasy setting like Middle-earth
           outgoingConnections:
             - output->"Array" KQXczbLkzL_QFjG4fQqKE/input2
-          visualData: -1008.5290408323401/287.3991224410053/300/240
+          visualData: -1008.5290408323401/287.3991224410053/300/240//
         '[z1jCBTkKd_SqkKzb2ARPI]:userInput "User Input"':
           data:
             prompt: This is an example question?
             useInput: true
           outgoingConnections:
             - output->"Assemble Prompt" zKRlWy2cdfSjYzaMkiZwJ/message2
-          visualData: 1020.9262528312603/528.2520721620051/250/274
+          visualData: 1020.9262528312603/528.2520721620051/250/274//
         '[zKRlWy2cdfSjYzaMkiZwJ]:assemblePrompt "Assemble Prompt"':
           outgoingConnections:
             - prompt->"Graph Output" H6sfMx6smlRGfdPb1OB4A/value
-          visualData: 1376.1339226383136/433.2884454952552/250/281
+          visualData: 1376.1339226383136/433.2884454952552/250/281//
     vTLQi8hE7_JmspagWbMjj:
       metadata:
         description: Given chat history, generate another iteration of ChatGPT and User
@@ -202,7 +204,7 @@ data:
             height: 639.1077454277531
             text: |
               #### 1. Use ChatGPT to generate the next situation
-          visualData: 659.08153558835/-278.4762934141443/856.793016304211/285
+          visualData: 659.08153558835/-278.4762934141443/856.793016304211/285//
         '[9wDx7mBnbqjyAdE5GnW6X]:graphInput "Graph Input"':
           data:
             dataType: chat-message[]
@@ -211,7 +213,7 @@ data:
           outgoingConnections:
             - data->"Assemble Prompt" OE9oEA2HAeyCJzKnMAlAB/message1
             - data->"Chat" SnEeUjZ6h6dM6V5-fnijr/prompt
-          visualData: 498.2437428720606/447.1094238033485/300/313
+          visualData: 498.2437428720606/447.1094238033485/300/313//
         '[EaxuXpCHNVL_D8L_H513Z]:prompt "Prompt"':
           data:
             enableFunctionCall: false
@@ -220,18 +222,18 @@ data:
             useTypeInput: false
           outgoingConnections:
             - output->"Assemble Prompt" OE9oEA2HAeyCJzKnMAlAB/message2
-          visualData: 2355.8931987698843/-241.59374278612572/250/302
+          visualData: 2355.8931987698843/-241.59374278612572/250/302//
         '[KBSJVpke_8BT0U3UnUzem]:comment "Comment"':
           data:
             backgroundColor: rgba(0,0,0,0.05)
             color: rgba(255,255,255,1)
             height: 664.5656817196393
             text: "#### 3. Combine the history, the ChatGPT response, and the User response"
-          visualData: 2287.1279341536974/-397.02232700707395/807.0554620664298/311
+          visualData: 2287.1279341536974/-397.02232700707395/807.0554620664298/311//
         '[OE9oEA2HAeyCJzKnMAlAB]:assemblePrompt "Assemble Prompt"':
           outgoingConnections:
             - prompt->"Graph Output" oQGGKj4CfPhsJjDQaZXoI/value
-          visualData: 2778.336224644202/42.14475731248859/250/312
+          visualData: 2778.336224644202/42.14475731248859/250/312//
         '[PGUfIUBf_XtVT1u0eKfl1]:comment "Comment"':
           data:
             backgroundColor: rgba(0,0,0,0.05)
@@ -239,14 +241,16 @@ data:
             height: 600
             text: "#### 2. Share ChatGPT's response with the user and get the User's
               response"
-          visualData: 1606.0898276353291/-237.83225309286487/600/320
+          visualData: 1606.0898276353291/-237.83225309286487/600/320//
         '[SnEeUjZ6h6dM6V5-fnijr]:chat "Chat"':
           data:
+            additionalParameters: []
             cache: false
             enableFunctionUse: false
             frequencyPenalty: 0
+            headers: []
             maxTokens: 250
-            model: gpt-3.5-turbo-16k-0613
+            model: gpt-4
             presencePenalty: 0
             stop: ""
             temperature: 1
@@ -266,7 +270,7 @@ data:
           outgoingConnections:
             - response->"Prompt" EaxuXpCHNVL_D8L_H513Z/input
             - response->"User Input" uyHRSGml9x70eH5FR3HMD/questions
-          visualData: 1260.8160785988268/-32.03414601648494/201/316
+          visualData: 1260.8160785988268/-32.03414601648494/201/316//
         '[lB9Jh6CODaVrCoB-E3JxI]:text "Text"':
           data:
             text: >+
@@ -289,21 +293,23 @@ data:
 
           outgoingConnections:
             - output->"Chat" SnEeUjZ6h6dM6V5-fnijr/systemPrompt
-          visualData: 762.1442898903098/-89.18722352257808/300/317
+          visualData: 762.1442898903098/-89.18722352257808/300/317//
         '[oQGGKj4CfPhsJjDQaZXoI]:graphOutput "Graph Output"':
           data:
             dataType: chat-message[]
             id: prompt
-          visualData: 3213.16959905003/29.299463125400905/300/322
+          visualData: 3213.16959905003/29.299463125400905/300/322//
         '[uyHRSGml9x70eH5FR3HMD]:userInput "User Input"':
           data:
             prompt: ""
             useInput: true
           outgoingConnections:
             - output->"Assemble Prompt" OE9oEA2HAeyCJzKnMAlAB/message3
-          visualData: 1797.7136653014277/68.06726944245918/250/323
+          visualData: 1797.7136653014277/68.06726944245918/250/323//
   metadata:
     description: An example project to demonstrate a basic chat loop, utilizing
       system prompts to implement a text-based RPG.
     id: mdaNOH2qO9sNDSGXgCrzi
     title: RPG
+  plugins: []
+  references: []


### PR DESCRIPTION
[gpt-3.5-turbo 16k has been deprecated](https://platform.openai.com/docs/deprecations/2023-11-06-chat-model-updates#2023-11-06-chat-model-updates) so the current example fails on initialization if a new model isn't selected. This just updates the models used in the example to be gpt-4 (all other changes seem to be from saving as a new data shape has been introduced since the creation of the example)

https://github.com/user-attachments/assets/b4296ba5-a7de-46a1-bf94-e29ce5b98c78

