### PR TITLE
Exposed the "internalProcessContext" variable for the Code Node

### DIFF
--- a/packages/app/src/components/editors/custom/AiAssistEditorBase.tsx
+++ b/packages/app/src/components/editors/custom/AiAssistEditorBase.tsx
@@ -100,7 +100,7 @@ export const AiAssistEditorBase = <TNodeData, TOutputs>({
           model: model!,
           api: api!,
         },
-        registry,
+        registry: registry as unknown as NodeRegistration,
         ...(await fillMissingSettingsFromEnvironmentVariables(settings, plugins)),
       });
 

--- a/packages/app/src/hooks/useAiGraphBuilder.ts
+++ b/packages/app/src/hooks/useAiGraphBuilder.ts
@@ -495,7 +495,7 @@ export function useAiGraphBuilder({ record, onFeedback }: { record: boolean; onF
         onUserEvent,
         nativeApi: new TauriNativeApi(),
         datasetProvider: new InMemoryDatasetProvider(data),
-        registry,
+        registry: registry as unknown as NodeRegistration,
         ...(await fillMissingSettingsFromEnvironmentVariables(settings, plugins)),
       });
 

--- a/packages/core/src/integrations/CodeRunner.ts
+++ b/packages/core/src/integrations/CodeRunner.ts
@@ -1,5 +1,6 @@
 import type { Inputs, Outputs } from '../index.js';
 import type { DataValue } from '../model/DataValue.js';
+import type { InternalProcessContext } from '../model/ProcessContext.js';
 
 // eslint-disable-next-line import/no-cycle -- There has to be a cycle if we're to import the entirety of Rivet here.
 import * as Rivet from '../exports.js';
@@ -8,6 +9,7 @@ export interface CodeRunnerOptions {
   includeRequire: boolean;
   includeFetch: boolean;
   includeRivet: boolean;
+  includeInternalProcessContext: boolean;
   includeProcess: boolean;
   includeConsole: boolean;
 }
@@ -18,6 +20,7 @@ export interface CodeRunner {
     code: string,
     inputs: Inputs,
     options: CodeRunnerOptions,
+    context: InternalProcessContext,
     graphInputs?: Record<string, DataValue>,
     contextValues?: Record<string, DataValue>
   ) => Promise<Outputs>;
@@ -28,6 +31,7 @@ export class IsomorphicCodeRunner implements CodeRunner {
     code: string,
     inputs: Inputs,
     options: CodeRunnerOptions,
+    context: InternalProcessContext,
     graphInputs?: Record<string, DataValue>,
     contextValues?: Record<string, DataValue>
   ): Promise<Outputs> {
@@ -57,6 +61,11 @@ export class IsomorphicCodeRunner implements CodeRunner {
       args.push(Rivet);
     }
 
+    if (options.includeInternalProcessContext) {
+      argNames.push('internalProcessContext');
+      args.push(context);
+    }
+
     if (graphInputs) {
       argNames.push('graphInputs');
       args.push(graphInputs);
@@ -82,6 +91,7 @@ export class NotAllowedCodeRunner implements CodeRunner {
     _code: string,
     _inputs: Inputs,
     _options: CodeRunnerOptions,
+    _context: InternalProcessContext,
     _graphInputs?: Record<string, DataValue>,
     _contextValues?: Record<string, DataValue>
   ): Promise<Outputs> {

--- a/packages/core/src/model/GraphProcessor.ts
+++ b/packages/core/src/model/GraphProcessor.ts
@@ -1530,7 +1530,7 @@ export class GraphProcessor {
         this.getRootProcessor().raiseEvent(event, data as DataValue);
       },
       contextValues: this.#contextValues,
-      externalFunctions: { ...this.#externalFunctions },
+      externalFunctions: this.#externalFunctions,
       onPartialOutputs: (partialOutputs) => {
         partialOutput?.(node, partialOutputs, index);
 

--- a/packages/core/src/model/nodes/CodeNode.ts
+++ b/packages/core/src/model/nodes/CodeNode.ts
@@ -26,6 +26,7 @@ export type CodeNodeData = {
   allowFetch?: boolean;
   allowRequire?: boolean;
   allowRivet?: boolean;
+  allowInternalProcessContext?: boolean;
   allowProcess?: boolean;
   allowConsole?: boolean;
 };
@@ -58,6 +59,7 @@ export class CodeNodeImpl extends NodeImpl<CodeNode> {
         allowFetch: false,
         allowRequire: false,
         allowRivet: false,
+        allowInternalProcessContext: false,
         allowProcess: false,
         allowConsole: false,
       },
@@ -141,6 +143,11 @@ export class CodeNodeImpl extends NodeImpl<CodeNode> {
       },
       {
         type: 'toggle',
+        label: 'Allow using `internalProcessContext`',
+        dataKey: 'allowInternalProcessContext',
+      },
+      {
+        type: 'toggle',
         label: 'Allow using `process`',
         dataKey: 'allowProcess',
         helperMessage: 'This is only available when using the Node executor.',
@@ -189,9 +196,11 @@ export class CodeNodeImpl extends NodeImpl<CodeNode> {
         includeFetch: this.data.allowFetch ?? false,
         includeRequire: this.data.allowRequire ?? false,
         includeRivet: this.data.allowRivet ?? false,
+        includeInternalProcessContext: this.data.allowInternalProcessContext ?? false,
         includeProcess: this.data.allowProcess ?? false,
         includeConsole: this.data.allowConsole ?? false,
       },
+      context,
       context.graphInputNodeValues,
       context.contextValues
     );

--- a/packages/docs/docs/node-reference/external-call.mdx
+++ b/packages/docs/docs/node-reference/external-call.mdx
@@ -19,7 +19,7 @@ import { runGraphInFile } from '@ironclad/rivet-node';
 await runGraphInFile({
   ...etc,
   externalFunctions: {
-    sum: (...args) => {
+    sum: (context, ...args) => {
       return {
         type: 'number',
         value: args.reduce((acc, curr) => acc + curr, 0);
@@ -38,7 +38,7 @@ External functions are useful for many use-cases, they can do things like:
 - Get user information about who is running the graph
 - Anything else you can think of!
 
-External functions are extremely powerful. They can only be used when running Rivet from a host application, and are not available when running Rivet in the Rivet applicaton. The external function nodes will error when running in the Rivet application. Use [Remote Debugging](../user-guide/remote-debugging.md) to run External Call nodes in the Rivet application.
+External functions are extremely powerful. They can be used when running Rivet from a host application, and are not normally available when running Rivet in the Rivet applicaton (see "FAQ"). Use [Remote Debugging](../user-guide/remote-debugging.md) to run External Call nodes in the Rivet application.
 
 <Tabs
   defaultValue="inputs"
@@ -126,7 +126,9 @@ If the external function errors, then the External Call node will error. If you 
 
 **Q: Can I use external functions when running Rivet in the Rivet application?**
 
-No, external functions are only available when running Rivet from a host application. Connect the [Remote Debugger](../user-guide/remote-debugging.md) to your host application to run external functions in the Rivet application.
+Only if you manually add external functions into the `internalProcessContext.externalFunctions` object using the [Code Node](./code.mdx). Make sure you enable "Allow using internalProcessContext" in the Code Node properties first. It can be helpful when debugging graphs in the Rivet application.
+
+You can also connect the [Remote Debugger](../user-guide/remote-debugging.md) to your host application to run external functions in the Rivet application.
 
 **Q: What do I return from an external function?**
 

--- a/packages/node/src/native/NodeCodeRunner.ts
+++ b/packages/node/src/native/NodeCodeRunner.ts
@@ -1,14 +1,16 @@
 import type { CodeRunner, CodeRunnerOptions, DataValue, Inputs, Outputs } from '@ironclad/rivet-core';
 import { createRequire } from 'node:module';
 import * as process from 'node:process';
+import type { InternalProcessContext } from '../../../core/src/model/ProcessContext.js';
 
 export class NodeCodeRunner implements CodeRunner {
   async runCode(
     code: string,
     inputs: Inputs,
     options: CodeRunnerOptions,
+    context: InternalProcessContext,
     graphInputs?: Record<string, DataValue>,
-    contextValues?: Record<string, DataValue>,
+    contextValues?: Record<string, DataValue>
   ): Promise<Outputs> {
     const argNames = ['inputs'];
     const args: any[] = [inputs];
@@ -40,6 +42,11 @@ export class NodeCodeRunner implements CodeRunner {
       argNames.push('Rivet');
       args.push(Rivet);
     }
+
+    if (options.includeInternalProcessContext) {
+      argNames.push('internalProcessContext');
+      args.push(context);
+    }    
 
     if (graphInputs) {
       argNames.push('graphInputs');


### PR DESCRIPTION
Exposed the new `internalProcessContext` variable for the Code Node. It's controlled by the new `Allow using internalProcessContext` switcher in the Code Node properties.

It enables multiple use cases including External Functions support in the Rivet app (helpful when debugging Graphs that use External Functions):
<img width="1136" height="519" alt="image" src="https://github.com/user-attachments/assets/278558a0-5445-4469-b162-14e796617d75" />

