### PR TITLE
Async nodes

### DIFF
--- a/packages/app/src/components/VisualNode.tsx
+++ b/packages/app/src/components/VisualNode.tsx
@@ -235,6 +235,7 @@ export const VisualNode = memo(
               isSplit: node.isSplitRun,
               disabled: node.disabled,
               conditional: !!node.isConditional,
+              async: !!node.isAsync,
             },
             changedClass,
           )}
@@ -389,6 +390,7 @@ const ZoomedOutVisualNodeContent: FC<{
           {!isReallyZoomedOut && (
             <div className="grab-area" {...handleAttributes} onClick={handleGrabClick}>
               {node.isSplitRun ? <GitForkLine /> : <></>}
+              {node.isAsync ? <span>ASYNC</span> : <></>}
               <div className="title-text">{node.title}</div>
             </div>
           )}
@@ -682,6 +684,7 @@ const NormalVisualNodeContent: FC<{
             onClick={handleGrabClick}
           >
             {node.isSplitRun ? <GitForkLine /> : <></>}
+            {node.isAsync ? <span>ASYNC</span> : <></>}
             <div className="title-text">{node.title}</div>
           </div>
           <div className="title-controls">

--- a/packages/app/src/components/editors/custom/AiAssistEditorBase.tsx
+++ b/packages/app/src/components/editors/custom/AiAssistEditorBase.tsx
@@ -100,7 +100,7 @@ export const AiAssistEditorBase = <TNodeData, TOutputs>({
           model: model!,
           api: api!,
         },
-        registry,
+        registry: registry as unknown as NodeRegistration,
         ...(await fillMissingSettingsFromEnvironmentVariables(settings, plugins)),
       });
 

--- a/packages/app/src/hooks/useAiGraphBuilder.ts
+++ b/packages/app/src/hooks/useAiGraphBuilder.ts
@@ -495,7 +495,7 @@ export function useAiGraphBuilder({ record, onFeedback }: { record: boolean; onF
         onUserEvent,
         nativeApi: new TauriNativeApi(),
         datasetProvider: new InMemoryDatasetProvider(data),
-        registry,
+        registry: registry as unknown as NodeRegistration,
         ...(await fillMissingSettingsFromEnvironmentVariables(settings, plugins)),
       });
 

--- a/packages/core/src/integrations/CodeRunner.ts
+++ b/packages/core/src/integrations/CodeRunner.ts
@@ -1,5 +1,6 @@
 import type { Inputs, Outputs } from '../index.js';
 import type { DataValue } from '../model/DataValue.js';
+import type { InternalProcessContext } from '../model/ProcessContext.js';
 
 // eslint-disable-next-line import/no-cycle -- There has to be a cycle if we're to import the entirety of Rivet here.
 import * as Rivet from '../exports.js';
@@ -8,6 +9,7 @@ export interface CodeRunnerOptions {
   includeRequire: boolean;
   includeFetch: boolean;
   includeRivet: boolean;
+  includeInternalProcessContext: boolean;
   includeProcess: boolean;
   includeConsole: boolean;
 }
@@ -18,6 +20,7 @@ export interface CodeRunner {
     code: string,
     inputs: Inputs,
     options: CodeRunnerOptions,
+    context: InternalProcessContext,
     graphInputs?: Record<string, DataValue>,
     contextValues?: Record<string, DataValue>
   ) => Promise<Outputs>;
@@ -28,6 +31,7 @@ export class IsomorphicCodeRunner implements CodeRunner {
     code: string,
     inputs: Inputs,
     options: CodeRunnerOptions,
+    context: InternalProcessContext,
     graphInputs?: Record<string, DataValue>,
     contextValues?: Record<string, DataValue>
   ): Promise<Outputs> {
@@ -57,6 +61,11 @@ export class IsomorphicCodeRunner implements CodeRunner {
       args.push(Rivet);
     }
 
+    if (options.includeInternalProcessContext) {
+      argNames.push('internalProcessContext');
+      args.push(context);
+    }
+
     if (graphInputs) {
       argNames.push('graphInputs');
       args.push(graphInputs);
@@ -82,6 +91,7 @@ export class NotAllowedCodeRunner implements CodeRunner {
     _code: string,
     _inputs: Inputs,
     _options: CodeRunnerOptions,
+    _context: InternalProcessContext,
     _graphInputs?: Record<string, DataValue>,
     _contextValues?: Record<string, DataValue>
   ): Promise<Outputs> {

--- a/packages/core/src/model/GraphProcessor.ts
+++ b/packages/core/src/model/GraphProcessor.ts
@@ -1530,7 +1530,7 @@ export class GraphProcessor {
         this.getRootProcessor().raiseEvent(event, data as DataValue);
       },
       contextValues: this.#contextValues,
-      externalFunctions: { ...this.#externalFunctions },
+      externalFunctions: this.#externalFunctions,
       onPartialOutputs: (partialOutputs) => {
         partialOutput?.(node, partialOutputs, index);
 

--- a/packages/core/src/model/GraphProcessor.ts
+++ b/packages/core/src/model/GraphProcessor.ts
@@ -1015,8 +1015,11 @@ export class GraphProcessor {
     await this.#processNodeIfAllInputsAvailable(node);
   }
 
-  /** If all inputs are present, all conditions met, processes the node. */
-  async #processNodeIfAllInputsAvailable(node: ChartNode): Promise<void> {
+  /** If all inputs are present, all conditions met, processes the node. For "Async" mode, set detached to true. */
+  async #processNodeIfAllInputsAvailable(node: ChartNode, detached: boolean = false): Promise<void> {
+    this.#emitTraceEvent(
+      `Entering #processNodeIfAllInputsAvailable for ${node.title} (${node.id}), detached=${detached}`,
+    );
     const builtInNode = node as BuiltInNodes;
 
     if (this.#ignoreNodes.has(node.id)) {
@@ -1110,6 +1113,41 @@ export class GraphProcessor {
     if (waitingForInputNode) {
       this.#emitTraceEvent(`Node ${node.title} is waiting for input node ${waitingForInputNode}`);
       return;
+    }
+
+    // If this node is marked as async, run it as a fire-and-forget task and do not
+    // block the processing queue or propagate to downstream nodes. Only applicable
+    // to terminal nodes (no output connections) that are not graphOutput nodes. 
+    // Do not re-trigger if already running in a detached mode.
+    if (node.isAsync && !detached) {
+      const hasOutgoing = this.#outputNodesFrom(node).nodes.length > 0;
+      const isGraphOutput = node.type === ('graphOutput' as BuiltInNodeType);
+      this.#emitTraceEvent(
+        `Async candidate ${node.title} (${node.id}): hasOutgoing=${hasOutgoing}, isGraphOutput=${isGraphOutput}`,
+      );
+
+      if (!hasOutgoing && !isGraphOutput) {
+        this.#emitTraceEvent(
+          `Starting async (fire-and-forget) node ${node.title} (${node.id}). Downstream nodes will not be scheduled from this node.`,
+        );
+
+        // Kick off processing without awaiting and without adding to the processing queue.
+        // Use the detached pathway to process the node and avoid scheduling downstream nodes.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        (async () => {
+          try {
+            await this.#processNodeIfAllInputsAvailable(node, true);
+          } catch {
+            // Errors are handled in #processNode via #nodeErrored
+          }
+        })();
+
+        return;
+      } else {
+        this.#emitTraceEvent(
+          `Node ${node.title} (${node.id}) is marked async but has downstream connections or is a graph output. Running normally.`,
+        );
+      }
     }
 
     this.#currentlyProcessing.add(node.id);
@@ -1239,14 +1277,16 @@ export class GraphProcessor {
     }
 
     // Node is finished, check if we can run any more nodes that depend on this one
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.#processingQueue.addAll(
-      outputNodes.nodes.map((outputNode) => async () => {
-        this.#emitTraceEvent(`Trying to run output node from ${node.title}: ${outputNode.title} (${outputNode.id})`);
+    if (!detached) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.#processingQueue.addAll(
+        outputNodes.nodes.map((outputNode) => async () => {
+          this.#emitTraceEvent(`Trying to run output node from ${node.title}: ${outputNode.title} (${outputNode.id})`);
 
-        await this.#processNodeIfAllInputsAvailable(outputNode);
-      }),
-    );
+          await this.#processNodeIfAllInputsAvailable(outputNode);
+        }),
+      );
+    }
   }
 
   #getAttachedDataTo(node: ChartNode | NodeId): AttachedNodeData {

--- a/packages/core/src/model/NodeBase.ts
+++ b/packages/core/src/model/NodeBase.ts
@@ -62,6 +62,13 @@ export interface NodeBase {
 
   /** If true, the node exposes an `if` port that lets it run conditionally. */
   isConditional?: boolean;
+
+  /**
+   * If true, the node will be executed asynchronously.
+   * The graph runner will not wait for this node to complete before finishing the graph
+   * Only works for terminal (no outgoing connections) nodes.
+   */
+  isAsync?: boolean;
 }
 
 /** Base type for a typed node. */

--- a/packages/core/src/model/nodes/CodeNode.ts
+++ b/packages/core/src/model/nodes/CodeNode.ts
@@ -26,6 +26,7 @@ export type CodeNodeData = {
   allowFetch?: boolean;
   allowRequire?: boolean;
   allowRivet?: boolean;
+  allowInternalProcessContext?: boolean;
   allowProcess?: boolean;
   allowConsole?: boolean;
 };
@@ -58,6 +59,7 @@ export class CodeNodeImpl extends NodeImpl<CodeNode> {
         allowFetch: false,
         allowRequire: false,
         allowRivet: false,
+        allowInternalProcessContext: false,
         allowProcess: false,
         allowConsole: false,
       },
@@ -141,6 +143,11 @@ export class CodeNodeImpl extends NodeImpl<CodeNode> {
       },
       {
         type: 'toggle',
+        label: 'Allow using `internalProcessContext`',
+        dataKey: 'allowInternalProcessContext',
+      },
+      {
+        type: 'toggle',
         label: 'Allow using `process`',
         dataKey: 'allowProcess',
         helperMessage: 'This is only available when using the Node executor.',
@@ -189,9 +196,11 @@ export class CodeNodeImpl extends NodeImpl<CodeNode> {
         includeFetch: this.data.allowFetch ?? false,
         includeRequire: this.data.allowRequire ?? false,
         includeRivet: this.data.allowRivet ?? false,
+        includeInternalProcessContext: this.data.allowInternalProcessContext ?? false,
         includeProcess: this.data.allowProcess ?? false,
         includeConsole: this.data.allowConsole ?? false,
       },
+      context,
       context.graphInputNodeValues,
       context.contextValues
     );

--- a/packages/core/src/utils/serialization/serialization_v4.ts
+++ b/packages/core/src/utils/serialization/serialization_v4.ts
@@ -57,6 +57,7 @@ type SerializedNode = {
   variants?: ChartNodeVariant<unknown>[];
   disabled?: boolean;
   isConditional?: boolean;
+  isAsync?: boolean;
 };
 
 /** x/y/width/zIndex */
@@ -246,6 +247,7 @@ function toSerializedNode(node: ChartNode, allNodes: ChartNode[], allConnections
     variants: (node.variants?.length ?? 0) > 0 ? node.variants : undefined,
     disabled: node.disabled ? true : undefined,
     isConditional: node.isConditional,
+    isAsync: node.isAsync ? true : undefined,
   };
 }
 
@@ -284,6 +286,7 @@ function fromSerializedNode(
       variants: serializedNode.variants ?? [],
       disabled: serializedNode.disabled,
       isConditional: serializedNode.isConditional,
+      isAsync: serializedNode.isAsync,
     },
     connections,
   ];

--- a/packages/docs/docs/node-reference/external-call.mdx
+++ b/packages/docs/docs/node-reference/external-call.mdx
@@ -19,7 +19,7 @@ import { runGraphInFile } from '@ironclad/rivet-node';
 await runGraphInFile({
   ...etc,
   externalFunctions: {
-    sum: (...args) => {
+    sum: (context, ...args) => {
       return {
         type: 'number',
         value: args.reduce((acc, curr) => acc + curr, 0);
@@ -38,7 +38,7 @@ External functions are useful for many use-cases, they can do things like:
 - Get user information about who is running the graph
 - Anything else you can think of!
 
-External functions are extremely powerful. They can only be used when running Rivet from a host application, and are not available when running Rivet in the Rivet applicaton. The external function nodes will error when running in the Rivet application. Use [Remote Debugging](../user-guide/remote-debugging.md) to run External Call nodes in the Rivet application.
+External functions are extremely powerful. They can be used when running Rivet from a host application, and are not normally available when running Rivet in the Rivet applicaton (see "FAQ"). Use [Remote Debugging](../user-guide/remote-debugging.md) to run External Call nodes in the Rivet application.
 
 <Tabs
   defaultValue="inputs"
@@ -126,7 +126,9 @@ If the external function errors, then the External Call node will error. If you 
 
 **Q: Can I use external functions when running Rivet in the Rivet application?**
 
-No, external functions are only available when running Rivet from a host application. Connect the [Remote Debugger](../user-guide/remote-debugging.md) to your host application to run external functions in the Rivet application.
+Only if you manually add external functions into the `internalProcessContext.externalFunctions` object using the [Code Node](./code.mdx). Make sure you enable "Allow using internalProcessContext" in the Code Node properties first. It can be helpful when debugging graphs in the Rivet application.
+
+You can also connect the [Remote Debugger](../user-guide/remote-debugging.md) to your host application to run external functions in the Rivet application.
 
 **Q: What do I return from an external function?**
 

--- a/packages/node/src/native/NodeCodeRunner.ts
+++ b/packages/node/src/native/NodeCodeRunner.ts
@@ -1,14 +1,16 @@
 import type { CodeRunner, CodeRunnerOptions, DataValue, Inputs, Outputs } from '@ironclad/rivet-core';
 import { createRequire } from 'node:module';
 import * as process from 'node:process';
+import type { InternalProcessContext } from '../../../core/src/model/ProcessContext.js';
 
 export class NodeCodeRunner implements CodeRunner {
   async runCode(
     code: string,
     inputs: Inputs,
     options: CodeRunnerOptions,
+    context: InternalProcessContext,
     graphInputs?: Record<string, DataValue>,
-    contextValues?: Record<string, DataValue>,
+    contextValues?: Record<string, DataValue>
   ): Promise<Outputs> {
     const argNames = ['inputs'];
     const args: any[] = [inputs];
@@ -40,6 +42,11 @@ export class NodeCodeRunner implements CodeRunner {
       argNames.push('Rivet');
       args.push(Rivet);
     }
+
+    if (options.includeInternalProcessContext) {
+      argNames.push('internalProcessContext');
+      args.push(context);
+    }    
 
     if (graphInputs) {
       argNames.push('graphInputs');


### PR DESCRIPTION
Added a new "Async Node" toggle for nodes. If a node is marked as async, it won't block the processing queue. The graph won't wait for this node to complete before finishing.

Async mode only works for nodes that don't have outgoing connections. Adding outgoing connections will turn the 'Async' toggle off. Node types that DO NOT get the "Async Node" toggle in the editor:
```
  'graphInput',
  'graphOutput',
  'context',
  'raiseEvent',
  'waitForEvent',
  'passthrough',
  'raceInputs',
  'setGlobal',
  'coalesce',
  'compare',
  'delay',
  'if',
  'ifElse',
  'loopController',
  'loopUntil',
  'match'
```
Use cases:
- **Logs & Notifications** — Non-critical HTTP calls where you don’t read the response.
- **Background Work Dispatch** — Enqueue to queues or trigger webhooks without awaiting completion.
- **Data Sinks & Maintenance** — Upserts to search/vector indexes or cache warming performed after producing the output.