### PR TITLE
Fixed issue with outdated HF inference libs.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "@gentrace/core": "^2.2.5",
     "@google-cloud/vertexai": "^0.1.3",
     "@google/genai": "^0.12.0",
-    "@huggingface/inference": "^2.6.4",
+    "@huggingface/inference": "^4.13.0",
     "assemblyai": "^4.6.0",
     "autoevals": "^0.0.26",
     "cron-parser": "^4.9.0",

--- a/packages/core/src/plugins/huggingface/nodes/ChatHuggingFace.ts
+++ b/packages/core/src/plugins/huggingface/nodes/ChatHuggingFace.ts
@@ -11,7 +11,7 @@ import {
   type PluginNodeImpl,
   type PortId,
 } from '../../../index.js';
-import { HfInference, HfInferenceEndpoint } from '@huggingface/inference';
+import { InferenceClient } from '@huggingface/inference';
 import { getInputOrData } from '../../../utils/inputs.js';
 import { coerceType } from '../../../utils/coerceType.js';
 import { dedent } from '../../../utils/misc.js';
@@ -273,7 +273,9 @@ export const ChatHuggingFaceNodeImpl: PluginNodeImpl<ChatHuggingFaceNode> = {
     const topP = getInputOrData(data, inputData, 'topP', 'number');
     const topK = getInputOrData(data, inputData, 'topK', 'number');
 
-    const hf = endpoint ? new HfInferenceEndpoint(endpoint, accessToken) : new HfInference(accessToken);
+    const hf = endpoint
+			? new InferenceClient(accessToken, {endpointUrl: endpoint} )
+			: new InferenceClient(accessToken);
 
     const generationStream = hf.textGenerationStream({
       inputs: prompt,

--- a/packages/core/src/plugins/huggingface/nodes/TextToImageHuggingFace.ts
+++ b/packages/core/src/plugins/huggingface/nodes/TextToImageHuggingFace.ts
@@ -11,7 +11,7 @@ import {
   type PluginNodeImpl,
   type PortId,
 } from '../../../index.js';
-import { HfInference, HfInferenceEndpoint } from '@huggingface/inference';
+import { InferenceClient } from '@huggingface/inference';
 import { dedent } from 'ts-dedent';
 import { pluginNodeDefinition } from '../../../model/NodeDefinition.js';
 import { getInputOrData } from '../../../utils/inputs.js';
@@ -218,19 +218,24 @@ export const TextToImageHuggingFaceNodeImpl: PluginNodeImpl<TextToImageHuggingFa
     const guidanceScale = getInputOrData(data, inputData, 'guidanceScale', 'number');
     const numInferenceSteps = getInputOrData(data, inputData, 'numInferenceSteps', 'number');
 
-    const hf = endpoint ? new HfInferenceEndpoint(endpoint, accessToken) : new HfInference(accessToken);
+    const hf = endpoint
+			? new InferenceClient(accessToken, {endpointUrl: endpoint} )
+			: new InferenceClient(accessToken);
 
-    const image = await hf.textToImage({
-      inputs: prompt,
-      model,
-      parameters: {
-        width,
-        height,
-        negative_prompt: negativePrompt,
-        guidance_scale: guidanceScale,
-        num_inference_steps: numInferenceSteps,
-      },
-    });
+    const image: Blob = await hf.textToImage(
+			{
+				inputs: prompt,
+				model,
+				parameters: {
+					width,
+					height,
+					negative_prompt: negativePrompt,
+					guidance_scale: guidanceScale,
+					num_inference_steps: numInferenceSteps,
+				},
+			},
+			{ outputType: "blob" }
+		);
 
     return {
       ['output' as PortId]: {


### PR DESCRIPTION
Started getting error:
[cause]: Error: "https://api-inference.huggingface.co is no longer supported. Please use https://router.huggingface.co/hf-inference instead."
2025-11-03T20:03:28:802 |-       at request (file:///usr/local/lib/node_modules/@alpic80/rivet-cli/node_modules/@huggingface/inference/dist/index.js:204:15)