### PR TITLE
Fix template project creation returning to welcome screen

### DIFF
--- a/packages/app/src/hooks/useNewProjectFromTemplate.ts
+++ b/packages/app/src/hooks/useNewProjectFromTemplate.ts
@@ -1,5 +1,11 @@
-import { useSetAtom } from 'jotai';
-import { loadedProjectState, projectState } from '../state/savedGraphs.js';
+import { useSetAtom, useAtomValue } from 'jotai';
+import {
+  loadedProjectState,
+  projectState,
+  openedProjectsState,
+  openedProjectsSortedIdsState,
+  type OpenedProjectInfo,
+} from '../state/savedGraphs.js';
 import {
   type GraphId,
   type NodeGraph,
@@ -18,6 +24,9 @@ import { nanoid } from 'nanoid';
 export function useNewProjectFromTemplate() {
   const setProject = useSetAtom(projectState);
   const setLoadedProject = useSetAtom(loadedProjectState);
+  const currentIds = useAtomValue(openedProjectsSortedIdsState);
+  const setOpenedProjectsSortedIds = useSetAtom(openedProjectsSortedIdsState);
+  const setOpenedProjects = useSetAtom(openedProjectsState);
   const setGraphData = useSetAtom(graphState);
   const setTrivetData = useSetAtom(trivetState);
 
@@ -66,13 +75,23 @@ export function useNewProjectFromTemplate() {
     });
 
     setLoadedProject({ loaded: false, path: '' });
-    setProject({
+    const projectWithNewId = {
       ...project,
       metadata: {
         ...project.metadata,
         id: nanoid() as ProjectId,
       },
-    });
+    };
+    setProject(projectWithNewId);
+
+    const newOpenedProjects: Record<ProjectId, OpenedProjectInfo> = {
+      [projectWithNewId.metadata.id]: {
+        project: projectWithNewId,
+        fsPath: null,
+      },
+    };
+    setOpenedProjects(newOpenedProjects);
+    setOpenedProjectsSortedIds([...currentIds, projectWithNewId.metadata.id]);
 
     const firstGraph = orderBy(Object.values(project.graphs), (g) => g.metadata!.name!)[0];
 


### PR DESCRIPTION
## Problem
When creating a new project from a template (AI Agent Template, MCP AI Agent Template, or Tutorial), clicking 'Create' caused the modal to close and return to the welcome screen instead of opening the template project.

## Root Cause
The `useNewProjectFromTemplate` hook was missing critical state updates that manage the list of opened projects. While it correctly set the project data, it didn't update `openedProjectsState` and `openedProjectsSortedIdsState`. This caused the app to think no projects were open (`openedProjectIds.length === 0`), so it continued displaying the welcome screen.

## Solution
Updated `useNewProjectFromTemplate.ts` to match the behavior of `useNewProject` by:

1. Added imports for `openedProjectsState`, `openedProjectsSortedIdsState`, and `OpenedProjectInfo` type
2. Added `useAtomValue` for reading current opened project IDs
3. Added setters for `openedProjectsState` and `openedProjectsSortedIdsState`
4. After creating the project with new ID, now properly updates the opened projects registry
5. Appends the new project ID to the sorted IDs list

This ensures that when a template is loaded, the app correctly tracks it as an opened project and displays it instead of returning to the welcome screen.

## Testing
- Create a new project from AI Agent Template → template opens correctly
- Create a new project from MCP AI Agent Template → template opens correctly
- Create a new project from Tutorial → template opens correctly
- Create a blank project → still works as before