### PR TITLE
Fix GPT-5 chat failures by stripping unsupported sampling params

### DIFF
--- a/packages/core/src/model/nodes/ChatNodeBase.ts
+++ b/packages/core/src/model/nodes/ChatNodeBase.ts
@@ -1119,6 +1119,12 @@ export const ChatNodeBase = {
 
           if (isReasoningModel) {
             options.max_completion_tokens = maxTokens;
+            // Reasoning models (o1, o3, o4, gpt-5) don't support sampling parameters
+            options.top_p = undefined;
+            options.frequency_penalty = undefined;
+            options.presence_penalty = undefined;
+            options.stop = undefined;
+            options.n = undefined;
           } else {
             options.temperature = useTopP ? undefined : temperature; // Not supported in o1-preview
             options.max_tokens = maxTokens;

--- a/packages/core/src/utils/openai.ts
+++ b/packages/core/src/utils/openai.ts
@@ -39,7 +39,7 @@ export const openaiModels = {
   'gpt-5-mini': {
     maxTokens: 400000,
     cost: {
-      prompt: 0.25 - 6,
+      prompt: 0.25e-6,
       completion: 2e-6,
     },
     displayName: 'GPT-5 mini',


### PR DESCRIPTION
## Summary
- Strip unsupported sampling parameters (`top_p`, `frequency_penalty`, `presence_penalty`, `stop`, `n`) for reasoning models (o1, o3, o4, gpt-5) in the `isReasoningModel` branch of `ChatNodeBase.ts`
- Fix `gpt-5-mini` cost typo: `0.25 - 6` (evaluates to `-5.75`) → `0.25e-6`

## Context
GPT-5 chat requests fail when a graph carries non-default sampling parameters from non-reasoning models. The OpenAI API rejects these with errors like `"Unsupported parameter: 'stop' is not supported with this model"`. The existing `isReasoningModel` branch already correctly uses `max_completion_tokens` instead of `max_tokens` and omits `temperature`, but does not clear the other unsupported parameters.

Fixes #531

## Test plan
- [x] `yarn build` — TypeScript compiles successfully
- [x] `yarn test` — all 63 existing tests pass
- [x] `yarn lint` — 0 errors (4 pre-existing warnings)
- [x] Validated against real OpenAI API: GPT-5 rejects requests with sampling params (400), succeeds without them (200)

🤖 Generated with [Claude Code](https://claude.ai/code)